### PR TITLE
EN-11274 Added AutoShutdownConfiguration to live examples

### DIFF
--- a/java/src/main/java/RtmpLiveEncoding.java
+++ b/java/src/main/java/RtmpLiveEncoding.java
@@ -15,6 +15,7 @@ import com.bitmovin.api.sdk.model.HlsManifest;
 import com.bitmovin.api.sdk.model.HlsManifestDefault;
 import com.bitmovin.api.sdk.model.HlsManifestDefaultVersion;
 import com.bitmovin.api.sdk.model.Input;
+import com.bitmovin.api.sdk.model.LiveAutoShutdownConfiguration;
 import com.bitmovin.api.sdk.model.LiveDashManifest;
 import com.bitmovin.api.sdk.model.LiveEncoding;
 import com.bitmovin.api.sdk.model.LiveHlsManifest;
@@ -98,6 +99,17 @@ public class RtmpLiveEncoding {
   private static List<AudioConfig> audioProfile =
       Collections.singletonList(new AudioConfig("AAC 128 kbit/s", 128_000L, "/audio/128kb"));
 
+  /**
+   * The settings for the automatic shutdown feature:
+   *  bytesReadTimeoutSeconds:
+   *     Automatically shutdown the live stream if there is no input anymore for a predefined number of seconds.
+   *  streamTimeoutMinutes:
+   *     Automatically shutdown the live stream after a predefined runtime in minutes.
+   *
+   */
+  private static long bytesReadTimeoutSeconds = 3600; // 1 hour
+  private static long streamTimeoutMinutes = 720; // 12 hours
+
   private static String streamKey = "bitmovin";
 
   public static void main(String[] args) throws Exception {
@@ -148,6 +160,15 @@ public class RtmpLiveEncoding {
     startRequest.addDashManifestsItem(liveDashManifest);
     startRequest.addHlsManifestsItem(liveHlsManifest);
     startRequest.setStreamKey(streamKey);
+
+    /*
+     Setting the autoShutdownConfiguration is optional,
+     if omitted the live encoding will not shut down automatically.
+     */
+    LiveAutoShutdownConfiguration autoShutdownConfiguration = new LiveAutoShutdownConfiguration();
+    autoShutdownConfiguration.setBytesReadTimeoutSeconds(bytesReadTimeoutSeconds);
+    autoShutdownConfiguration.setStreamTimeoutMinutes(streamTimeoutMinutes);
+    startRequest.setAutoShutdownConfiguration(autoShutdownConfiguration);
 
     startLiveEncodingAndWaitUntilRunning(encoding, startRequest);
     LiveEncoding liveEncoding = waitForLiveEncodingDetails(encoding);

--- a/java/src/main/java/tutorials/RedundantRtmpLiveEncoding.java
+++ b/java/src/main/java/tutorials/RedundantRtmpLiveEncoding.java
@@ -17,6 +17,7 @@ import com.bitmovin.api.sdk.model.HlsManifest;
 import com.bitmovin.api.sdk.model.HlsManifestDefault;
 import com.bitmovin.api.sdk.model.HlsManifestDefaultVersion;
 import com.bitmovin.api.sdk.model.Input;
+import com.bitmovin.api.sdk.model.LiveAutoShutdownConfiguration;
 import com.bitmovin.api.sdk.model.LiveDashManifest;
 import com.bitmovin.api.sdk.model.LiveEncoding;
 import com.bitmovin.api.sdk.model.LiveHlsManifest;
@@ -101,6 +102,17 @@ public class RedundantRtmpLiveEncoding {
   private static List<AudioConfig> audioProfile =
       Collections.singletonList(new AudioConfig("128kbit", 128_000L, "/audio/128kb"));
 
+  /**
+   * The settings for the automatic shutdown feature:
+   *  bytesReadTimeoutSeconds:
+   *     Automatically shutdown the live stream if there is no input anymore for a predefined number of seconds.
+   *  streamTimeoutMinutes:
+   *     Automatically shutdown the live stream after a predefined runtime in minutes.
+   *
+   */
+  private static long bytesReadTimeoutSeconds = 3600; // 1 hour
+  private static long streamTimeoutMinutes = 720; // 12 hours
+
   public static void main(String[] args) throws Exception {
     configProvider = new ConfigProvider(args);
     bitmovinApi =
@@ -157,6 +169,15 @@ public class RedundantRtmpLiveEncoding {
     startRequest.addDashManifestsItem(liveDashManifest);
     startRequest.addHlsManifestsItem(liveHlsManifest);
     startRequest.setStreamKey("notused");
+
+    /*
+     Setting the autoShutdownConfiguration is optional,
+     if omitted the live encoding will not shut down automatically.
+     */
+    LiveAutoShutdownConfiguration autoShutdownConfiguration = new LiveAutoShutdownConfiguration();
+    autoShutdownConfiguration.setBytesReadTimeoutSeconds(bytesReadTimeoutSeconds);
+    autoShutdownConfiguration.setStreamTimeoutMinutes(streamTimeoutMinutes);
+    startRequest.setAutoShutdownConfiguration(autoShutdownConfiguration);
 
     startLiveEncodingAndWaitUntilRunning(encoding, startRequest);
     LiveEncoding liveEncoding = waitForLiveEncodingDetails(encoding);

--- a/java/src/main/java/tutorials/SrtLiveEncoding.java
+++ b/java/src/main/java/tutorials/SrtLiveEncoding.java
@@ -17,6 +17,7 @@ import com.bitmovin.api.sdk.model.HlsManifest;
 import com.bitmovin.api.sdk.model.HlsManifestDefault;
 import com.bitmovin.api.sdk.model.HlsManifestDefaultVersion;
 import com.bitmovin.api.sdk.model.Input;
+import com.bitmovin.api.sdk.model.LiveAutoShutdownConfiguration;
 import com.bitmovin.api.sdk.model.LiveDashManifest;
 import com.bitmovin.api.sdk.model.LiveEncoding;
 import com.bitmovin.api.sdk.model.LiveHlsManifest;
@@ -101,6 +102,17 @@ public class SrtLiveEncoding {
   private static List<AudioConfig> audioProfile =
       Collections.singletonList(new AudioConfig("128kbit", 128_000L, "/audio/128kb"));
 
+  /**
+   * The settings for the automatic shutdown feature:
+   *  bytesReadTimeoutSeconds:
+   *     Automatically shutdown the live stream if there is no input anymore for a predefined number of seconds.
+   *  streamTimeoutMinutes:
+   *     Automatically shutdown the live stream after a predefined runtime in minutes.
+   *
+   */
+  private static long bytesReadTimeoutSeconds = 3600; // 1 hour
+  private static long streamTimeoutMinutes = 720; // 12 hours
+
   public static void main(String[] args) throws Exception {
     configProvider = new ConfigProvider(args);
     bitmovinApi =
@@ -153,6 +165,15 @@ public class SrtLiveEncoding {
     StartLiveEncodingRequest startRequest = new StartLiveEncodingRequest();
     startRequest.addDashManifestsItem(liveDashManifest);
     startRequest.addHlsManifestsItem(liveHlsManifest);
+
+    /*
+     Setting the autoShutdownConfiguration is optional,
+     if omitted the live encoding will not shut down automatically.
+     */
+    LiveAutoShutdownConfiguration autoShutdownConfiguration = new LiveAutoShutdownConfiguration();
+    autoShutdownConfiguration.setBytesReadTimeoutSeconds(bytesReadTimeoutSeconds);
+    autoShutdownConfiguration.setStreamTimeoutMinutes(streamTimeoutMinutes);
+    startRequest.setAutoShutdownConfiguration(autoShutdownConfiguration);
 
     startLiveEncodingAndWaitUntilRunning(encoding, startRequest);
     LiveEncoding liveEncoding = waitForLiveEncodingDetails(encoding);


### PR DESCRIPTION
https://bitmovin.atlassian.net/browse/EN-11274

- Added LiveAutoShutdownConfiguration to
  -  RtmpLiveEncoding
  - RedundantRtmpLiveEncoding
  - SrtLiveEncoding
- The goal is
  - to educate the API users about this feature
  - to ensure that there are no "forgotten" live encodings racking up a huge bill for a customer  