### PR TITLE
Add example to show how to start a live encoding with the new HD pricing option

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@ For full documentation of all available API endpoints, see the [Bitmovin API ref
    Prevent blocking of ads by delivering a continuous content stream
 + [RTMP Live Encoding](#rtmp-live-encoding)  
    Start a live encoding using an RTMP stream as input
++ [RTMP Live HD Encoding](#rtmp-live-hd-encoding)  
+   Start a live encoding with HD option using an RTMP stream as input
 + [Batch Encoding](#batch-encoding)  
    Efficiently start and track a large number of encodings
 + [Multiple Inputs Concatenation](#multiple-inputs-concatenation)  
@@ -231,6 +233,27 @@ Required configuration parameters:
 <a href="python/src/rtmp_live_encoding.py">Python</a>
 
 This example shows how to configure and start a live encoding using default DASH and HLS manifests.
+For more information see: https://bitmovin.com/live-encoding-live-streaming
+
+Required configuration parameters:
++ `BITMOVIN_API_KEY` ([?](#BITMOVIN_API_KEY))
++ `BITMOVIN_TENANT_ORG_ID` ([?](#BITMOVIN_TENANT_ORG_ID))
++ `S3_OUTPUT_BUCKET_NAME` ([?](#S3_OUTPUT_BUCKET_NAME))
++ `S3_OUTPUT_ACCESS_KEY` ([?](#S3_OUTPUT_ACCESS_KEY))
++ `S3_OUTPUT_SECRET_KEY` ([?](#S3_OUTPUT_SECRET_KEY))
++ `S3_OUTPUT_BASE_PATH` ([?](#S3_OUTPUT_BASE_PATH))
+
+---
+### RTMP Live HD Encoding
+
+<a href="java/src/main/java/RtmpLiveHdEncoding.java">Java</a> -
+<a href="dotnet/Bitmovin.Api.Sdk.Examples/RtmpLiveHdEncoding.cs">C#</a> -
+<a href="javascript/src/RtmpLiveHdEncoding.ts">TS/JS</a> -
+<a href="php/src/RtmpLiveHdEncoding.php">PHP</a> -
+<a href="python/src/rtmp_live_hd_encoding.py">Python</a>
+
+
+This example shows how to configure and start a live encoding with HD option using default DASH and HLS manifests.
 For more information see: https://bitmovin.com/live-encoding-live-streaming
 
 Required configuration parameters:

--- a/dotnet/Bitmovin.Api.Sdk.Examples/Bitmovin.Api.Sdk.Examples.csproj
+++ b/dotnet/Bitmovin.Api.Sdk.Examples/Bitmovin.Api.Sdk.Examples.csproj
@@ -2,11 +2,11 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>netcoreapp5.0</TargetFramework>
+        <TargetFramework>netcoreapp7.0</TargetFramework>
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="Bitmovin.Api.Sdk" Version="1.103.0" />
+      <PackageReference Include="Bitmovin.Api.Sdk" Version="1.174.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/dotnet/Bitmovin.Api.Sdk.Examples/RtmpLiveHdEncoding.cs
+++ b/dotnet/Bitmovin.Api.Sdk.Examples/RtmpLiveHdEncoding.cs
@@ -1,0 +1,523 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using Bitmovin.Api.Sdk.Common;
+using Bitmovin.Api.Sdk.Common.Logging;
+using Bitmovin.Api.Sdk.Examples.common;
+using Bitmovin.Api.Sdk.Models;
+using Stream = Bitmovin.Api.Sdk.Models.Stream;
+using LiveAutoShutdownConfiguration = Bitmovin.Api.Sdk.Models.LiveAutoShutdownConfiguration;
+
+namespace Bitmovin.Api.Sdk.Examples
+{
+    /// <summary>
+    /// This example shows how to configure and start a live encoding using default DASH and HLS manifests.
+    /// For more information see: https://bitmovin.com/live-encoding-live-streaming/<para />
+    ///
+    /// The following configuration parameters are expected:
+    /// <list type="bullet">
+    /// <item>
+    /// <term>BITMOVIN_API_KEY</term>
+    /// <description>Your API key for the Bitmovin API</description>
+    /// </item>
+    /// <item>
+    /// <term>BITMOVIN_TENANT_ORG_ID</term>
+    /// <description>(optional) The ID of the Organisation in which you want to perform the encoding.</description>
+    /// </item>
+    /// <item>
+    /// <term>S3_OUTPUT_BUCKET_NAME</term>
+    /// <description>The name of your S3 output bucket. Example: my-bucket-name</description>
+    /// </item>
+    /// <item>
+    /// <term>S3_OUTPUT_ACCESS_KEY</term>
+    /// <description>The access key of your S3 output bucket</description>
+    /// </item>
+    /// <item>
+    /// <term>S3_OUTPUT_SECRET_KEY</term>
+    /// <description>The secret key of your S3 output bucket</description>
+    /// </item>
+    /// <item>
+    /// <term>S3_OUTPUT_BASE_PATH</term>
+    /// <description>The base path on your S3 output bucket where content will be written.
+    /// Example: /outputs</description>
+    /// </item>
+    /// </list><para />
+    ///
+    /// Configuration parameters will be retrieved from these sources in the listed order:
+    /// <list type="bullet">
+    /// <item>
+    /// <term>command line arguments</term>
+    /// <description>(eg BITMOVIN_API_KEY=xyz)</description>
+    /// </item>
+    /// <item>
+    /// <term>properties file located in the root folder of the C# examples at ./examples.properties</term>
+    /// <description>(see examples.properties.template as reference)</description>
+    /// </item>
+    /// <item>
+    /// <term>environment variables</term>
+    /// </item>
+    /// <item>
+    /// <term>properties file located in the home folder at ~/.bitmovin/examples.properties</term>
+    /// <description>(see examples.properties.template as reference)</description>
+    /// </item>
+    /// </list>
+    /// </summary>
+    public class RtmpLiveHdEncoding : IExample
+    {
+        private ConfigProvider _configProvider;
+        private BitmovinApi _bitmovinApi;
+        private const string StreamKey = "myStreamKey";
+
+        /*
+         * Make sure to set the correct resolution of your input video, so the aspect ratio can be calculated.
+         */
+        private const int InputVideoHeight = 1080;
+        private const int InputVideoWidth = 1920;
+        private const double AspectRatio = (double) InputVideoWidth / InputVideoHeight;
+
+        private const int MaxMinutesWaitingForLiveEncodingDetails = 5;
+        private const int MaxMinutesWaitingForEncodingStatus = 5;
+
+        /*
+         * Automatically shutdown the live stream if there is no input anymore for a predefined number of seconds.
+         */
+        private const long BytesReadTimeoutSeconds = 3600; // 1 hour
+
+        /*
+         * Automatically shutdown the live stream after a predefined runtime in minutes.
+         */
+        private const long StreamTimeoutMinutes = 12 * 60; // 12 hours
+
+        public async Task RunExample(string[] args)
+        {
+            _configProvider = new ConfigProvider(args);
+            _bitmovinApi = BitmovinApi.Builder
+                .WithApiKey(_configProvider.GetBitmovinApiKey())
+                // uncomment the following line if you are working with a multi-tenant account
+                // .WithTenantOrgIdKey(_configProvider.GetBitmovinTenantOrgId())
+                .WithLogger(new ConsoleLogger())
+                .Build();
+
+            var encoding = await CreateEncoding("Live encoding HD example", "Live encoding with RTMP input");
+
+            var input = await GetRtmpInput();
+            var inputFilePath = "live";
+
+            var output = await CreateS3Output(_configProvider.GetS3OutputBucketName(),
+                _configProvider.GetS3OutputAccessKey(),
+                _configProvider.GetS3OutputSecretKey());
+
+            // Add an H.264 video stream to the encoding
+            var h264VideoConfig = await CreateH264VideoConfiguration();
+            var h264VideoStream = await CreateStream(encoding, input, inputFilePath, h264VideoConfig);
+
+            // Add an AAC audio stream to the encoding
+            var aacConfig = await CreateAacAudioConfiguration();
+            var aacAudioStream = await CreateStream(encoding, input, inputFilePath, aacConfig);
+
+            await CreateFmp4Muxing(encoding, output, $"/video/${h264VideoConfig.Height}p", h264VideoStream);
+            await CreateFmp4Muxing(encoding, output, $"/audio/${aacConfig.Bitrate! / 1000}kbps", aacAudioStream);
+
+            var dashManifest = await CreateDefaultDashManifest(encoding, output, "/");
+            var hlsManifest = await CreateDefaultHlsManifest(encoding, output, "/");
+
+            var liveDashManifest = new LiveDashManifest()
+            {
+                ManifestId = dashManifest.Id
+            };
+
+            var liveHlsManifest = new LiveHlsManifest()
+            {
+                ManifestId = hlsManifest.Id
+            };
+
+            /*
+             * Setting the autoShutdownConfiguration is optional,
+             * if omitted the live encoding will not shut down automatically.
+             */
+            var liveAutoShutdownConfiguration = new LiveAutoShutdownConfiguration()
+            {
+                BytesReadTimeoutSeconds = BytesReadTimeoutSeconds,
+                StreamTimeoutMinutes = StreamTimeoutMinutes
+            };
+
+            var startLiveEncodingRequest = new StartLiveChannelEncodingRequest()
+            {
+                DashManifests = new List<LiveDashManifest>() {liveDashManifest},
+                HlsManifests = new List<LiveHlsManifest>() {liveHlsManifest},
+                AutoShutdownConfiguration = liveAutoShutdownConfiguration,
+                StreamKey = StreamKey
+            };
+
+            await StartLiveEncodingAndWaitUntilRunning(encoding, startLiveEncodingRequest);
+            var liveEncoding = await WaitForLiveEncodingDetails(encoding);
+
+            Console.WriteLine("Live encoding is up and ready for ingest. " +
+                              $"RTMP URL: rtmp://{liveEncoding.EncoderIp}/live StreamKey: {liveEncoding.StreamKey}");
+
+            /*
+            * This will enable you to shut down the live encoding from within your script.
+            * In production, it is naturally recommended to stop the encoding by using the Bitmovin dashboard
+            * or an independent API call - https://bitmovin.com/docs/encoding/api-reference/sections/encodings#/Encoding/PostEncodingEncodingsLiveStopByEncodingId
+            */
+            Console.WriteLine("Press any key to shutdown the live encoding...");
+            Console.ReadKey();
+
+            Console.WriteLine("Shutting down live encoding.");
+            await _bitmovinApi.Encoding.Encodings.Live.StopAsync(encoding.Id);
+            await WaitUntilEncodingIsInState(encoding, Status.FINISHED);
+        }
+
+        /// <summary>
+        /// This method starts the live encoding with HD option<para />
+        ///
+        /// API endpoint:
+        /// https://bitmovin.com/docs/encoding/api-reference/sections/encodings#/Encoding/PostEncodingEncodingsLiveStartByEncodingId
+        /// </summary>
+        /// <param name="encoding">The encoding that should be started and checked until it is running</param>
+        /// <param name="startLiveEncodingRequest">The request object that is sent with the start call</param>
+        private async Task StartLiveEncodingAndWaitUntilRunning(Models.Encoding encoding,
+            StartLiveChannelEncodingRequest startLiveEncodingRequest)
+        {
+            await _bitmovinApi.Encoding.Encodings.Live.Hd.StartAsync(encoding.Id, startLiveEncodingRequest);
+            await WaitUntilEncodingIsInState(encoding, Status.RUNNING);
+        }
+
+        /// <summary>
+        /// Tries to get the live details of the encoding. It could take a few minutes until this info is available.
+        /// <para />
+        ///
+        /// API endpoint:
+        /// https://bitmovin.com/docs/encoding/api-reference/sections/encodings#/Encoding/GetEncodingEncodingsLiveByEncodingId
+        /// </summary>
+        /// <param name="encoding">The encoding for which the live encoding details should be retrieved</param>
+        /// <exception cref="SystemException"></exception>
+        private async Task<LiveEncoding> WaitForLiveEncodingDetails(Models.Encoding encoding)
+        {
+            Console.WriteLine(
+                $"Waiting until live encodings are available (max {MaxMinutesWaitingForLiveEncodingDetails} minutes) ...");
+
+            var checkIntervalInSeconds = 10;
+            var maxAttempts = MaxMinutesWaitingForLiveEncodingDetails * (60 / checkIntervalInSeconds);
+            var attempt = 0;
+
+            BitmovinApiException bitmovinApiException;
+            do
+            {
+                try
+                {
+                    return await _bitmovinApi.Encoding.Encodings.Live.GetAsync(encoding.Id);
+                }
+                catch (BitmovinApiException ex)
+                {
+                    bitmovinApiException = ex;
+                    await Task.Delay(checkIntervalInSeconds * 1000);
+                }
+            } while (attempt++ < maxAttempts);
+
+            throw new SystemException("Failed to retrieve live encoding details withing " +
+                                      $"{MaxMinutesWaitingForLiveEncodingDetails} minutes. Aborting.",
+                bitmovinApiException);
+        }
+
+        /// <summary>
+        /// Periodically checks the status of the encoding.<para />
+        ///
+        /// Note: You can also use our webhooks API instead of polling the status. For more information checkout
+        /// the API spec:<br />
+        /// https://bitmovin.com/docs/encoding/api-reference/sections/notifications-webhooks
+        ///
+        /// API endpoint:
+        /// https://bitmovin.com/docs/encoding/api-reference/sections/encodings#/Encoding/GetEncodingEncodingsStatusByEncodingId
+        /// </summary>
+        /// <param name="encoding">The encoding that should have the expected status</param>
+        /// <param name="expectedStatus">The expected status the provided encoding should have. See {@link Status}</param>
+        /// <exception cref="SystemException"></exception>
+        private async Task WaitUntilEncodingIsInState(Models.Encoding encoding, Status expectedStatus)
+        {
+            Console.WriteLine($"Waiting for encoding to have status {expectedStatus} " +
+                              $"(max {MaxMinutesWaitingForEncodingStatus} minutes) ...");
+
+            var checkIntervalInSeconds = 10;
+            var maxAttempts = MaxMinutesWaitingForEncodingStatus * (60 / checkIntervalInSeconds);
+            var attempt = 0;
+
+            do
+            {
+                var serviceTaskStatus = await _bitmovinApi.Encoding.Encodings.StatusAsync(encoding.Id);
+
+                Console.WriteLine($"Encoding with id {encoding.Id} has status: {serviceTaskStatus.Status}");
+
+                if (serviceTaskStatus.Status == Status.ERROR)
+                {
+                    throw new SystemException(
+                        $@"Error while waiting for encoding with ID {encoding.Id} to have the status {expectedStatus}");
+                }
+
+                if (serviceTaskStatus.Status == expectedStatus)
+                {
+                    return;
+                }
+
+                await Task.Delay(checkIntervalInSeconds * 1000);
+            } while (attempt++ < maxAttempts);
+
+            throw new SystemException($"Live encoding did not switch to state {expectedStatus} within " +
+                                      $"{MaxMinutesWaitingForEncodingStatus}. Aborting");
+        }
+
+        /// <summary>
+        /// Creates a DASH default manifest that automatically includes all representations configured in
+        /// the encoding.<para />
+        ///
+        /// API endpoint:
+        /// https://bitmovin.com/docs/encoding/api-reference/sections/manifests#/Encoding/PostEncodingManifestsDashDefault
+        /// </summary>
+        /// <param name="encoding">The encoding for which the manifest should be generated</param>
+        /// <param name="output">The output where the manifest should be written to</param>
+        /// <param name="outputPath">The path to which the manifest should be written</param>
+        private Task<DashManifestDefault> CreateDefaultDashManifest(Models.Encoding encoding, Output output,
+            string outputPath)
+        {
+            var dashManifestDefault = new DashManifestDefault()
+            {
+                EncodingId = encoding.Id,
+                Outputs = new List<EncodingOutput>() {BuildEncodingOutput(output, outputPath)},
+                ManifestName = "stream.mpd",
+                Version = DashManifestDefaultVersion.V1
+            };
+
+            return _bitmovinApi.Encoding.Manifests.Dash.Default.CreateAsync(dashManifestDefault);
+        }
+
+        /// <summary>
+        /// Creates a HLS default manifest that automatically includes all representations configured in
+        /// the encoding.<para />
+        ///
+        /// API endpoint:
+        /// https://bitmovin.com/docs/encoding/api-reference/sections/manifests#/Encoding/PostEncodingManifestsHlsDefault
+        /// </summary>
+        /// <param name="encoding">The encoding for which the manifest should be generated</param>
+        /// <param name="output">The output where the manifest should be written to</param>
+        /// <param name="outputPath">The path to which the manifest should be written</param>
+        private Task<HlsManifestDefault> CreateDefaultHlsManifest(Models.Encoding encoding, Output output,
+            string outputPath)
+        {
+            var hlsManifestDefault = new HlsManifestDefault()
+            {
+                EncodingId = encoding.Id,
+                Outputs = new List<EncodingOutput>() {BuildEncodingOutput(output, outputPath)},
+                Name = "master.m3u8",
+                Version = HlsManifestDefaultVersion.V1
+            };
+
+            return _bitmovinApi.Encoding.Manifests.Hls.Default.CreateAsync(hlsManifestDefault);
+        }
+
+        /// <summary>
+        /// Retrieves the first RTMP input. This is an automatically generated resource and read-only.<para />
+        ///
+        /// API endpoint:
+        /// https://bitmovin.com/docs/encoding/api-reference/sections/inputs#/Encoding/GetEncodingInputsRtmp
+        /// </summary>
+        private async Task<RtmpInput> GetRtmpInput()
+        {
+            return (await _bitmovinApi.Encoding.Inputs.Rtmp.ListAsync()).Items.ElementAt(0);
+        }
+
+        /// <summary>
+        /// Creates a resource representing an AWS S3 cloud storage bucket to which generated content will
+        /// be transferred. For alternative output methods see
+        /// https://bitmovin.com/docs/encoding/articles/supported-input-output-storages for the list of
+        /// supported input and output storages.<para />
+        ///
+        /// The provided credentials need to allow read, write and list operations.
+        /// delete should also be granted to allow overwriting of existing files. See
+        /// https://bitmovin.com/docs/encoding/faqs/how-do-i-create-a-aws-s3-bucket-which-can-be-used-as-output-location
+        /// for creating an S3 bucket and setting permissions for further information<para />
+        ///
+        /// For reasons of simplicity, a new output resource is created on each execution of this
+        /// example. In production use, this method should be replaced by a get call
+        /// (https://bitmovin.com/docs/encoding/api-reference/sections/outputs#/Encoding/GetEncodingOutputsS3)
+        /// retrieving an existing resource.<para />
+        ///
+        /// API endpoint:
+        /// https://bitmovin.com/docs/encoding/api-reference/sections/outputs#/Encoding/PostEncodingOutputsS3
+        /// </summary>
+        /// <param name="bucketName">The name of the S3 bucket</param>
+        /// <param name="accessKey">The access key of your S3 account</param>
+        /// <param name="secretKey">The secret key of your S3 account</param>
+        private Task<S3Output> CreateS3Output(string bucketName, string accessKey, string secretKey)
+        {
+            var s3Output = new S3Output()
+            {
+                BucketName = bucketName,
+                AccessKey = accessKey,
+                SecretKey = secretKey
+            };
+
+            return _bitmovinApi.Encoding.Outputs.S3.CreateAsync(s3Output);
+        }
+
+        /// <summary>
+        /// Creates an Encoding object. This is the base object to configure your encoding.<para />
+        ///
+        /// API endpoint:
+        /// https://bitmovin.com/docs/encoding/api-reference/sections/encodings#/Encoding/PostEncodingEncodings
+        /// </summary>
+        /// <param name="name">This is the name of the encoding</param>
+        /// <param name="description">This is the description of the encoding</param>
+        private Task<Models.Encoding> CreateEncoding(string name, string description)
+        {
+            var encoding = new Models.Encoding()
+            {
+                Name = name,
+                Description = description
+            };
+
+            return _bitmovinApi.Encoding.Encodings.CreateAsync(encoding);
+        }
+
+        /// <summary>
+        /// Creates a stream which binds an input file to a codec configuration.
+        /// The stream is used for muxings later on.<para />
+        ///
+        /// API endpoint:
+        /// https://bitmovin.com/docs/encoding/api-reference/sections/encodings#/Encoding/PostEncodingEncodingsStreamsByEncodingId
+        /// </summary>
+        /// <param name="encoding">The encoding to add the stream onto</param>
+        /// <param name="input">The input that should be used</param>
+        /// <param name="inputPath">The path to the input file</param>
+        /// <param name="configuration">The codec configuration to be applied to the stream</param>
+        private Task<Stream> CreateStream(Models.Encoding encoding, Input input, string inputPath,
+            CodecConfiguration configuration)
+        {
+            var streamInput = new StreamInput()
+            {
+                InputId = input.Id,
+                InputPath = inputPath,
+                SelectionMode = StreamSelectionMode.AUTO
+            };
+
+            var stream = new Stream()
+            {
+                InputStreams = new List<StreamInput>() {streamInput},
+                CodecConfigId = configuration.Id
+            };
+
+            return _bitmovinApi.Encoding.Encodings.Streams.CreateAsync(encoding.Id, stream);
+        }
+
+        /// <summary>
+        /// Creates a configuration for the H.264 video codec to be applied to video streams.<para />
+        ///
+        /// The output resolution is defined by setting the height to 1080 pixels. Width will be determined
+        /// automatically to maintain the aspect ratio of your input video.<para />
+        ///
+        /// To keep things simple, we use a quality-optimized Live preset configuration, which will apply proven settings
+        /// for the codec. See How to optimize your H264 codec configuration for different use-cases
+        /// (https://bitmovin.com/docs/encoding/tutorials/how-to-optimize-your-h264-codec-configuration-for-different-use-cases)
+        /// for alternative presets.<para />
+        ///
+        /// API endpoint:
+        /// https://bitmovin.com/docs/encoding/api-reference/sections/configurations#/Encoding/PostEncodingConfigurationsVideoH264
+        /// </summary>
+        private Task<H264VideoConfiguration> CreateH264VideoConfiguration()
+        {
+            var config = new H264VideoConfiguration()
+            {
+                Name = "H.264 1080p 3 Mbit/s",
+                PresetConfiguration = PresetConfiguration.LIVE_STANDARD,
+                Height = InputVideoHeight,
+                Width = (int) Math.Ceiling(AspectRatio * InputVideoHeight),
+                Bitrate = 3000000
+            };
+
+            return _bitmovinApi.Encoding.Configurations.Video.H264.CreateAsync(config);
+        }
+
+        /// <summary>
+        /// Creates a configuration for the AAC audio codec to be applied to audio streams.<para />
+        ///
+        /// API endpoint:
+        /// https://bitmovin.com/docs/encoding/api-reference/sections/configurations#/Encoding/PostEncodingConfigurationsAudioAac
+        /// </summary>
+        private Task<AacAudioConfiguration> CreateAacAudioConfiguration()
+        {
+            var config = new AacAudioConfiguration()
+            {
+                Name = "AAC 128 kbit/s",
+                Bitrate = 128_000L
+            };
+
+            return _bitmovinApi.Encoding.Configurations.Audio.Aac.CreateAsync(config);
+        }
+
+        /// <summary>
+        /// Creates a fragmented MP4 muxing. This will generate segments with a given segment length for
+        /// adaptive streaming.<para />
+        ///
+        /// API endpoint:
+        /// https://bitmovin.com/docs/encoding/api-reference/all#/Encoding/PostEncodingEncodingsMuxingsFmp4ByEncodingId
+        /// </summary>
+        /// <param name="encoding">The encoding where to add the muxing to</param>
+        /// <param name="output">The output that should be used for the muxing to write the segments to</param>
+        /// <param name="outputPath">The output path where the fragmented segments will be written to</param>
+        /// <param name="stream">The stream to be muxed</param>
+        private Task<Fmp4Muxing> CreateFmp4Muxing(Models.Encoding encoding, Output output, string outputPath,
+            Stream stream)
+        {
+            var muxingStream = new MuxingStream()
+            {
+                StreamId = stream.Id
+            };
+
+            var muxing = new Fmp4Muxing()
+            {
+                SegmentLength = 4,
+                Outputs = new List<EncodingOutput>() {BuildEncodingOutput(output, outputPath)},
+                Streams = new List<MuxingStream>() {muxingStream}
+            };
+
+            return _bitmovinApi.Encoding.Encodings.Muxings.Fmp4.CreateAsync(encoding.Id, muxing);
+        }
+
+        /// <summary>
+        /// Builds an EncodingOutput object which defines where the output content (e.g. of a muxing) will
+        /// be written to. Public read permissions will be set for the files written, so they can be
+        /// accessed easily via HTTP.
+        /// </summary>
+        /// <param name="output">The output resource to be used by the EncodingOutput</param>
+        /// <param name="outputPath">The path where the content will be written to</param>
+        private EncodingOutput BuildEncodingOutput(Output output, string outputPath)
+        {
+            var aclEntry = new AclEntry()
+            {
+                Permission = AclPermission.PUBLIC_READ
+            };
+
+            var encodingOutput = new EncodingOutput()
+            {
+                OutputPath = BuildAbsolutePath(outputPath),
+                OutputId = output.Id,
+                Acl = new List<AclEntry>() {aclEntry}
+            };
+
+            return encodingOutput;
+        }
+
+        /// <summary>
+        /// Builds an absolute path by concatenating the S3_OUTPUT_BASE_PATH configuration parameter, the
+        /// name of this example class and the given relative path<para />
+        ///
+        /// e.g.: /s3/base/path/ClassName/relative/path
+        /// </summary>
+        /// <param name="relativePath">The relative path that is concatenated</param>
+        private string BuildAbsolutePath(string relativePath)
+        {
+            return Path.Join(_configProvider.GetS3OutputBasePath(), nameof(RtmpLiveHdEncoding), relativePath);
+        }
+    }
+}

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -45,12 +45,12 @@
         <dependency>
             <groupId>com.bitmovin.api.sdk</groupId>
             <artifactId>bitmovin-api-sdk</artifactId>
-            <version>1.118.0</version>
+            <version>1.174.0</version>
         </dependency>
         <dependency>
             <groupId>io.github.openfeign</groupId>
             <artifactId>feign-slf4j</artifactId>
-            <version>11.8</version>
+            <version>12.4</version>
         </dependency>
         <dependency>
             <groupId>ch.qos.logback</groupId>

--- a/java/src/main/java/RtmpLiveHdEncoding.java
+++ b/java/src/main/java/RtmpLiveHdEncoding.java
@@ -1,0 +1,560 @@
+import com.bitmovin.api.sdk.BitmovinApi;
+import com.bitmovin.api.sdk.common.BitmovinException;
+import com.bitmovin.api.sdk.model.AacAudioConfiguration;
+import com.bitmovin.api.sdk.model.AclEntry;
+import com.bitmovin.api.sdk.model.AclPermission;
+import com.bitmovin.api.sdk.model.CodecConfiguration;
+import com.bitmovin.api.sdk.model.DashManifest;
+import com.bitmovin.api.sdk.model.DashManifestDefault;
+import com.bitmovin.api.sdk.model.DashManifestDefaultVersion;
+import com.bitmovin.api.sdk.model.Encoding;
+import com.bitmovin.api.sdk.model.EncodingOutput;
+import com.bitmovin.api.sdk.model.Fmp4Muxing;
+import com.bitmovin.api.sdk.model.H264VideoConfiguration;
+import com.bitmovin.api.sdk.model.HlsManifest;
+import com.bitmovin.api.sdk.model.HlsManifestDefault;
+import com.bitmovin.api.sdk.model.HlsManifestDefaultVersion;
+import com.bitmovin.api.sdk.model.Input;
+import com.bitmovin.api.sdk.model.LiveAutoShutdownConfiguration;
+import com.bitmovin.api.sdk.model.LiveDashManifest;
+import com.bitmovin.api.sdk.model.LiveEncoding;
+import com.bitmovin.api.sdk.model.LiveHlsManifest;
+import com.bitmovin.api.sdk.model.ManifestGenerator;
+import com.bitmovin.api.sdk.model.MuxingStream;
+import com.bitmovin.api.sdk.model.Output;
+import com.bitmovin.api.sdk.model.PresetConfiguration;
+import com.bitmovin.api.sdk.model.RtmpInput;
+import com.bitmovin.api.sdk.model.S3Output;
+import com.bitmovin.api.sdk.model.StartLiveChannelEncodingRequest;
+import com.bitmovin.api.sdk.model.Status;
+import com.bitmovin.api.sdk.model.Stream;
+import com.bitmovin.api.sdk.model.StreamInput;
+import com.bitmovin.api.sdk.model.StreamSelectionMode;
+import com.bitmovin.api.sdk.model.Task;
+import common.ConfigProvider;
+import feign.Logger.Level;
+import feign.slf4j.Slf4jLogger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.nio.file.Paths;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Scanner;
+
+/**
+ * This example shows how to configure and start a live encoding using default DASH and HLS
+ * manifests. For more information see: https://bitmovin.com/live-encoding-live-streaming/
+ *
+ * <p>The following configuration parameters are expected:
+ *
+ * <ul>
+ *   <li>BITMOVIN_API_KEY - Your API key for the Bitmovin API
+ *   <li>BITMOVIN_TENANT_ORG_ID - (optional) The ID of the Organisation in which you want to perform
+ *       the encoding.
+ *   <li>S3_OUTPUT_BUCKET_NAME - The name of your S3 output bucket. Example: my-bucket-name
+ *   <li>S3_OUTPUT_ACCESS_KEY - The access key of your S3 output bucket
+ *   <li>S3_OUTPUT_SECRET_KEY - The secret key of your S3 output bucket
+ *   <li>S3_OUTPUT_BASE_PATH - The base path on your S3 output bucket where content will be written.
+ *       Example: /outputs
+ * </ul>
+ *
+ * <p>Configuration parameters will be retrieved from these sources in the listed order: *
+ *
+ * <ol>
+ *   <li>command line arguments (eg BITMOVIN_API_KEY=xyz)
+ *   <li>properties file located in the root folder of the JAVA examples at ./examples.properties
+ *       (see examples.properties.template as reference)
+ *   <li>environment variables
+ *   <li>properties file located in the home folder at ~/.bitmovin/examples.properties (see
+ *       examples.properties.template as reference)
+ * </ol>
+ */
+public class RtmpLiveHdEncoding {
+
+  private static final Logger logger = LoggerFactory.getLogger(RtmpLiveHdEncoding.class);
+
+  private static BitmovinApi bitmovinApi;
+  private static ConfigProvider configProvider;
+
+  private static int maxMinutesToWaitForLiveEncodingDetails = 5;
+  private static int maxMinutesToWaitForEncodingStatus = 5;
+
+  /** This list defines the video renditions that will be generated.
+   * Starting from encoder version <a href="https://developer.bitmovin.com/encoding/docs/encoder-21000-21490#21170">
+   * 2.117.0</a>, you don't need to set both width and height. If you set one, the other is calculated automatically.
+   * In this example, we've set only the height for each version.
+   */
+  private static List<VideoConfig> videoProfile =
+      Arrays.asList(
+          new VideoConfig("H.264 480p live", 800_000L, 480, "/video/480p"),
+          new VideoConfig("H.264 720p live", 1_200_000L, 720, "/video/720p"),
+          new VideoConfig("H.264 1080p live", 3_000_000L, 1080, "/video/1080p"));
+
+  /** This list defines the audio renditions that will be generated */
+  private static List<AudioConfig> audioProfile =
+      Collections.singletonList(new AudioConfig("AAC 128 kbit/s", 128_000L, "/audio/128kb"));
+
+  /**
+   * Automatically shutdown the live stream if there is no input anymore for a predefined number of seconds.
+   */
+  private static long bytesReadTimeoutSeconds = 3600; // 1 hour
+
+  /**
+   * Automatically shutdown the live stream after a predefined runtime in minutes.
+   */
+  private static long streamTimeoutMinutes = 12 * 60; // 12 hours
+
+  private static String streamKey = "bitmovin";
+
+  public static void main(String[] args) throws Exception {
+    configProvider = new ConfigProvider(args);
+    bitmovinApi =
+        BitmovinApi.builder()
+            .withApiKey(configProvider.getBitmovinApiKey())
+            // uncomment the following line if you are working with a multi-tenant account
+                .withTenantOrgId(configProvider.getBitmovinTenantOrgId())
+            .withLogger(
+                new Slf4jLogger(), Level.BASIC) // set the logger and log level for the API client
+            .build();
+
+    Encoding encoding =
+        createEncoding("Live Encoding HD Test", "Live encoding with HLS and DASH manifest");
+    RtmpInput input = getRtmpInput();
+    Output output =
+        createS3Output(
+            configProvider.getS3OutputBucketName(),
+            configProvider.getS3OutputAccessKey(),
+            configProvider.getS3OutputSecretKey());
+
+    for (VideoConfig videoConfig : videoProfile) {
+      H264VideoConfiguration h264Config =
+          createH264VideoConfig(videoConfig.name, videoConfig.height, videoConfig.bitRate);
+      Stream stream = createStream(encoding, input, h264Config);
+
+      createFmp4Muxing(encoding, stream, output, videoConfig.outputPath);
+    }
+
+    for (AudioConfig audioConfig : audioProfile) {
+      AacAudioConfiguration aacConfig = createAacAudioConfig(audioConfig.name, audioConfig.bitrate);
+      Stream audioStream = createStream(encoding, input, aacConfig);
+
+      createFmp4Muxing(encoding, audioStream, output, audioConfig.outputPath);
+    }
+
+    DashManifest dashManifest = createDefaultDashManifest(output, "/", encoding);
+    HlsManifest hlsManifest = createDefaultHlsManifest(output, "/", encoding);
+
+    LiveDashManifest liveDashManifest = new LiveDashManifest();
+    liveDashManifest.setManifestId(dashManifest.getId());
+
+    LiveHlsManifest liveHlsManifest = new LiveHlsManifest();
+    liveHlsManifest.setManifestId(hlsManifest.getId());
+
+    StartLiveChannelEncodingRequest startRequest = new StartLiveChannelEncodingRequest();
+    startRequest.addDashManifestsItem(liveDashManifest);
+    startRequest.addHlsManifestsItem(liveHlsManifest);
+    startRequest.setManifestGenerator(ManifestGenerator.V2);
+    startRequest.setStreamKey(streamKey);
+
+    /*
+     Setting the autoShutdownConfiguration is optional,
+     if omitted the live encoding will not shut down automatically.
+     */
+    LiveAutoShutdownConfiguration autoShutdownConfiguration = new LiveAutoShutdownConfiguration();
+    autoShutdownConfiguration.setBytesReadTimeoutSeconds(bytesReadTimeoutSeconds);
+    autoShutdownConfiguration.setStreamTimeoutMinutes(streamTimeoutMinutes);
+    startRequest.setAutoShutdownConfiguration(autoShutdownConfiguration);
+
+    startLiveEncodingAndWaitUntilRunning(encoding, startRequest);
+    LiveEncoding liveEncoding = waitForLiveEncodingDetails(encoding);
+
+    logger.info(
+        "Live encoding is up and ready for ingest. RTMP URL: rtmp://{}/live StreamKey: {}",
+        liveEncoding.getEncoderIp(),
+        liveEncoding.getStreamKey());
+
+    /*
+    This will enable you to shut down the live encoding from within your script.
+    In production, it is naturally recommended to stop the encoding by using the Bitmovin dashboard
+    or an independent API call - https://bitmovin.com/docs/encoding/api-reference/sections/encodings#/Encoding/PostEncodingEncodingsLiveStopByEncodingId
+    */
+    Scanner scanner = new Scanner(System.in);
+    logger.info("Press Enter to shutdown the live encoding...");
+    scanner.nextLine();
+
+    logger.info("Shutting down live encoding!");
+    bitmovinApi.encoding.encodings.live.stop(encoding.getId());
+    waitUntilEncodingIsInState(encoding, Status.FINISHED);
+  }
+
+  /**
+   * Tries to get the live details of the encoding. It could take a few minutes until this info is
+   * available.
+   *
+   * <p>API endpoint:
+   * https://developer.bitmovin.com/encoding/reference/getencodingencodingslivebyencodingid
+   *
+   * @param encoding The encoding for which the live encoding details should be retrieved
+   */
+  private static LiveEncoding waitForLiveEncodingDetails(Encoding encoding)
+      throws InterruptedException {
+
+    logger.info(
+        "Waiting until live encoding details are available (max {} minutes) ...",
+        maxMinutesToWaitForLiveEncodingDetails);
+
+    int checkIntervalInSeconds = 10;
+    int maxAttempts = maxMinutesToWaitForLiveEncodingDetails * (60 / checkIntervalInSeconds);
+    int attempt = 0;
+
+    BitmovinException bitmovinException;
+
+    do {
+      try {
+        return bitmovinApi.encoding.encodings.live.get(encoding.getId());
+      } catch (BitmovinException e) {
+        attempt++;
+        bitmovinException = e;
+        Thread.sleep(checkIntervalInSeconds * (long) 1000);
+      }
+    } while (attempt < maxAttempts);
+    throw new Error(
+        String.format(
+            "Failed to retrieve live encoding details within %d minutes. Aborting.",
+            maxMinutesToWaitForLiveEncodingDetails),
+        bitmovinException);
+  }
+
+  /**
+   * Periodically checks the status of the encoding.
+   *
+   * <p>Note: You can also use our webhooks API instead of polling the status. For more information
+   * checkout the API spec:
+   * https://bitmovin.com/docs/encoding/api-reference/sections/notifications-webhooks
+   *
+   * <p>API endpoint:
+   * https://developer.bitmovin.com/encoding/reference/getencodingencodingsstatusbyencodingid
+   *
+   * @param encoding The encoding that should have the expected status
+   * @param expectedStatus The expected status the provided encoding should have. See {@link Status}
+   */
+  private static void waitUntilEncodingIsInState(Encoding encoding, Status expectedStatus)
+      throws InterruptedException, BitmovinException {
+
+    logger.info(
+        "Waiting for encoding to have status {} (max {} minutes) ...",
+        expectedStatus,
+        maxMinutesToWaitForEncodingStatus);
+
+    int checkIntervalInSeconds = 10;
+    int maxAttempts = maxMinutesToWaitForEncodingStatus * (60 / checkIntervalInSeconds);
+    int attempt = 0;
+
+    Task task;
+    do {
+      task = bitmovinApi.encoding.encodings.status(encoding.getId());
+      logger.info("Encoding with id {} has status: {}", encoding.getId(), task.getStatus());
+      if (task.getStatus() == Status.ERROR) {
+        throw new Error(
+            String.format(
+                "Error while waiting for encoding with ID %s to have the status %s",
+                encoding.getId(), expectedStatus));
+      }
+      if (task.getStatus() == expectedStatus) {
+        return;
+      }
+      Thread.sleep(checkIntervalInSeconds * (long) 1000);
+    } while (attempt++ < maxAttempts);
+    throw new Error(
+        String.format(
+            "Live encoding did not switch to state %s within %d minutes. Aborting.",
+            expectedStatus, maxMinutesToWaitForEncodingStatus));
+  }
+
+  /**
+   * This method starts the live encoding with HD option
+   *
+   * <p>API endpoint:
+   * https://developer.bitmovin.com/encoding/reference/postencodingencodingslivechannelstartbyencodingid
+   *
+   * @param encoding The encoding that should be started and checked until it is running
+   * @param startEncodingRequest The request object that is sent with the start call
+   */
+  private static void startLiveEncodingAndWaitUntilRunning(
+      Encoding encoding, StartLiveChannelEncodingRequest startEncodingRequest)
+      throws InterruptedException, BitmovinException {
+    bitmovinApi.encoding.encodings.live.hd.start(encoding.getId(), startEncodingRequest);
+    waitUntilEncodingIsInState(encoding, Status.RUNNING);
+  }
+
+  /**
+   * Creates a default DASH manifest that automatically includes all the representations configured.
+   * in the encoding.
+   *
+   * <p>API endpoint:
+   * https://developer.bitmovin.com/encoding/reference/postencodingmanifestsdashdefault
+   *
+   * @param output The output to which the manifest should be written
+   * @param outputPath The path where the generated manifest should be located
+   * @param encoding The encoding for which the manifest should be generated
+   */
+  private static DashManifestDefault createDefaultDashManifest(
+      Output output, String outputPath, Encoding encoding) {
+    DashManifestDefault dashManifestDefault = new DashManifestDefault();
+    dashManifestDefault.setEncodingId(encoding.getId());
+    dashManifestDefault.setManifestName("stream.mpd");
+    dashManifestDefault.setVersion(DashManifestDefaultVersion.V1);
+    dashManifestDefault.addOutputsItem(buildEncodingOutput(output, outputPath));
+
+    return bitmovinApi.encoding.manifests.dash.defaultapi.create(dashManifestDefault);
+  }
+
+  /**
+   * Creates a default HLS manifest that automatically includes all representations configured in.
+   * the encoding.
+   *
+   * <p>API endpoint:
+   * https://developer.bitmovin.com/encoding/reference/postencodingmanifestshlsdefault
+   *
+   * @param output The output to which the manifest should be written
+   * @param outputPath The path where the generated manifest should be located
+   * @param encoding The encoding for which the manifest should be generated
+   */
+  private static HlsManifestDefault createDefaultHlsManifest(
+      Output output, String outputPath, Encoding encoding) {
+    HlsManifestDefault hlsManifestDefault = new HlsManifestDefault();
+    hlsManifestDefault.setEncodingId(encoding.getId());
+    hlsManifestDefault.addOutputsItem(buildEncodingOutput(output, outputPath));
+    hlsManifestDefault.setName("master.m3u8");
+    hlsManifestDefault.setVersion(HlsManifestDefaultVersion.V1);
+
+    return bitmovinApi.encoding.manifests.hls.defaultapi.create(hlsManifestDefault);
+  }
+
+  /**
+   * Builds an absolute path by concatenating the S3_OUTPUT_BASE_PATH configuration parameter, the
+   * name of this example class and the given relative path
+   *
+   * <p>e.g.: /s3/base/path/ClassName/relative/path
+   *
+   * @param relativePath The relative path that is concatenated
+   * @return The absolute path
+   */
+  public static String buildAbsolutePath(String relativePath) {
+    String className = RtmpLiveHdEncoding.class.getSimpleName();
+    return Paths.get(configProvider.getS3OutputBasePath(), className, relativePath).toString();
+  }
+
+  /**
+   * Creates a fragmented MP4 muxing. This will generate segments with a given segment length for
+   * adaptive streaming.
+   *
+   * <p>API endpoint:
+   * https://developer.bitmovin.com/encoding/reference/postencodingencodingsmuxingsfmp4byencodingid
+   *
+   * @param encoding The encoding where to add the muxing to
+   * @param output The output that should be used for the muxing to write the segments to
+   * @param outputPath The output path where the fragmented segments will be written to
+   * @param stream The stream that is associated with the muxing
+   */
+  private static void createFmp4Muxing(
+      Encoding encoding, Stream stream, Output output, String outputPath) throws BitmovinException {
+    MuxingStream muxingStream = new MuxingStream();
+    muxingStream.setStreamId(stream.getId());
+
+    Fmp4Muxing muxing = new Fmp4Muxing();
+    muxing.addOutputsItem(buildEncodingOutput(output, outputPath));
+    muxing.addStreamsItem(muxingStream);
+    muxing.setSegmentLength(4.0);
+
+    bitmovinApi.encoding.encodings.muxings.fmp4.create(encoding.getId(), muxing);
+  }
+
+  /**
+   * Builds an EncodingOutput object which defines where the output content (e.g. of a muxing) will
+   * be written to. Public read permissions will be set for the files written, so they can be
+   * accessed easily via HTTP.
+   *
+   * @param output The output resource to be used by the EncodingOutput
+   * @param outputPath The path where the content will be written to
+   */
+  private static EncodingOutput buildEncodingOutput(Output output, String outputPath) {
+    AclEntry aclEntry = new AclEntry();
+    aclEntry.setPermission(AclPermission.PUBLIC_READ);
+
+    EncodingOutput encodingOutput = new EncodingOutput();
+    encodingOutput.setOutputPath(buildAbsolutePath(outputPath));
+    encodingOutput.setOutputId(output.getId());
+    encodingOutput.addAclItem(aclEntry);
+    return encodingOutput;
+  }
+
+  /**
+   * Retrieves the first RTMP input. This is an automatically generated resource and read-only.
+   *
+   * <p>API endpoint:
+   * https://developer.bitmovin.com/encoding/reference/getencodinginputsrtmpbyinputid
+   */
+  private static RtmpInput getRtmpInput() throws BitmovinException {
+    return bitmovinApi.encoding.inputs.rtmp.list().getItems().get(0);
+  }
+
+  /**
+   * Creates a resource representing an AWS S3 cloud storage bucket to which generated content will
+   * be transferred. For alternative output methods see <a
+   * href="https://bitmovin.com/docs/encoding/articles/supported-input-output-storages">list of
+   * supported input and output storages</a>
+   *
+   * <p>The provided credentials need to allow <i>read</i>, <i>write</i> and <i>list</i> operations.
+   * <i>delete</i> should also be granted to allow overwriting of existings files. See <a
+   * href="https://bitmovin.com/docs/encoding/faqs/how-do-i-create-a-aws-s3-bucket-which-can-be-used-as-output-location">creating
+   * an S3 bucket and setting permissions</a> for further information
+   *
+   * <p>For reasons of simplicity, a new output resource is created on each execution of this
+   * example. In production use, this method should be replaced by a <a
+   * href="https://bitmovin.com/docs/encoding/api-reference/sections/outputs#/Encoding/GetEncodingOutputsS3">get
+   * call</a> retrieving an existing resource.
+   *
+   * <p>API endpoint:
+   * https://developer.bitmovin.com/encoding/reference/postencodingoutputss3
+   *
+   * @param bucketName The name of the S3 bucket
+   * @param accessKey The access key of your S3 account
+   * @param secretKey The secret key of your S3 account
+   */
+  private static S3Output createS3Output(String bucketName, String accessKey, String secretKey)
+      throws BitmovinException {
+    S3Output s3Output = new S3Output();
+    s3Output.setBucketName(bucketName);
+    s3Output.setAccessKey(accessKey);
+    s3Output.setSecretKey(secretKey);
+
+    return bitmovinApi.encoding.outputs.s3.create(s3Output);
+  }
+
+  /**
+   * Creates an Encoding object. This is the base object to configure your encoding.
+   *
+   * <p>API endpoint:
+   * https://developer.bitmovin.com/encoding/reference/postencodingencodings
+   *
+   * @param name This is the name of the encoding
+   * @param description This is the description of the encoding
+   */
+  private static Encoding createEncoding(String name, String description) throws BitmovinException {
+    Encoding encoding = new Encoding();
+    encoding.setName(name);
+    encoding.setDescription(description);
+
+    return bitmovinApi.encoding.encodings.create(encoding);
+  }
+
+  /**
+   * Creates a stream which binds an input file to a codec configuration. The stream is used later
+   * for muxings. For RTMP live inputs, the input path should be the application name and the
+   * position of the input streams must be provided.
+   *
+   * <p>API endpoint:
+   * https://developer.bitmovin.com/encoding/reference/postencodingencodingsstreamsbyencodingid
+   *
+   * @param encoding The encoding where to add the stream to
+   * @param codecConfiguration The codec configuration to be applied to the stream
+   */
+  private static Stream createStream(
+      Encoding encoding, Input input, CodecConfiguration codecConfiguration)
+      throws BitmovinException {
+    StreamInput streamInput = new StreamInput();
+    streamInput.setInputId(input.getId());
+    streamInput.setInputPath("live");
+    streamInput.setSelectionMode(StreamSelectionMode.AUTO);
+
+    Stream stream = new Stream();
+    stream.addInputStreamsItem(streamInput);
+    stream.setCodecConfigId(codecConfiguration.getId());
+
+    return bitmovinApi.encoding.encodings.streams.create(encoding.getId(), stream);
+  }
+
+  /**
+   * Creates a configuration for the H.264 video codec to be applied to video streams.
+   *
+   * <p>API endpoint:
+   * https://developer.bitmovin.com/encoding/reference/postencodingconfigurationsvideoh264
+   *
+   * To keep things simple, we use a standard live preset configuration, which will
+   * apply proven settings for the codec. See <a
+   * href="https://developer.bitmovin.com/encoding/docs/how-to-optimize-your-h264-codec-configuration-for-different-use-cases">How
+   * to optimize your H264 codec configuration for different use-cases</a> for alternative presets.
+   *
+   * @param name The name of the configuration resource being created
+   * @param height The height of the output video
+   * @param bitrate The target bitrate of the output video
+   */
+  private static H264VideoConfiguration createH264VideoConfig(String name, int height, long bitrate)
+      throws BitmovinException {
+    H264VideoConfiguration config = new H264VideoConfiguration();
+    config.setName(name);
+    config.setPresetConfiguration(PresetConfiguration.LIVE_STANDARD);
+    config.setHeight(height);
+    config.setBitrate(bitrate);
+
+    return bitmovinApi.encoding.configurations.video.h264.create(config);
+  }
+
+  /**
+   * Creates a configuration for the AAC audio codec to be applied to audio streams.
+   *
+   * <p>API endpoint:
+   * https://developer.bitmovin.com/encoding/reference/postencodingconfigurationsaudioaac
+   *
+   * @param name The name of the configuration resource being created
+   * @param bitrate The target bitrate for the encoded audio
+   */
+  private static AacAudioConfiguration createAacAudioConfig(String name, long bitrate) throws BitmovinException {
+    AacAudioConfiguration config = new AacAudioConfiguration();
+    config.setName(name);
+    config.setBitrate(bitrate);
+
+    return bitmovinApi.encoding.configurations.audio.aac.create(config);
+  }
+
+  private static class VideoConfig {
+    private String name;
+    private Long bitRate;
+    private Integer height;
+    private String outputPath;
+
+    /**
+     * @param name The name of the video configuration
+     * @param bitRate The target output bitrate of the video configuration
+     * @param height The target output height of the video configuration
+     * @param outputPath The output path for this video configuration
+     */
+    private VideoConfig(
+        String name, Long bitRate, Integer height, String outputPath) {
+      this.name = name;
+      this.bitRate = bitRate;
+      this.height = height;
+      this.outputPath = outputPath;
+    }
+  }
+
+  private static class AudioConfig {
+    private String name;
+    private Long bitrate;
+    private String outputPath;
+
+    /**
+     * @param name The name of the audio configuration
+     * @param bitrate The target output bitrate of the audio configuration
+     * @param outputPath The output path for this audio configuration
+     */
+    public AudioConfig(String name, Long bitrate, String outputPath) {
+      this.name = name;
+      this.bitrate = bitrate;
+      this.outputPath = outputPath;
+    }
+  }
+}

--- a/javascript/package-lock.json
+++ b/javascript/package-lock.json
@@ -1,8 +1,371 @@
 {
   "name": "bitmovin-typescript-examples",
   "version": "1.0.0",
-  "lockfileVersion": 1,
+  "lockfileVersion": 2,
   "requires": true,
+  "packages": {
+    "": {
+      "name": "bitmovin-typescript-examples",
+      "version": "1.0.0",
+      "license": "MIT",
+      "dependencies": {
+        "@bitmovin/api-sdk": "^1.174.0",
+        "@types/node": "^14.14.20",
+        "prettier": "^2.5.1",
+        "ts-node": "^9.1.1",
+        "typescript": "^4.1.3"
+      }
+    },
+    "node_modules/@bitmovin/api-sdk": {
+      "version": "1.174.0",
+      "resolved": "https://registry.npmjs.org/@bitmovin/api-sdk/-/api-sdk-1.174.0.tgz",
+      "integrity": "sha512-q+3KUgoqvAKVLJTk+TxtFb6NXSBGWCdo9knkqOSPJj9L256NvE4FJuIaYd07fPiN5U1pnexnJFd+gmBWZrNefA==",
+      "dependencies": {
+        "es6-promise": "^4.2.5",
+        "isomorphic-fetch": ">=3.0.0",
+        "typedoc": "0.22.15",
+        "url-join": "^4.0.0"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "14.14.20",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.20.tgz",
+      "integrity": "sha512-Y93R97Ouif9JEOWPIUyU+eyIdyRqQR0I8Ez1dzku4hDx34NWh4HbtIc3WNzwB1Y9ULvNGeu5B8h8bVL5cAk4/A=="
+    },
+    "node_modules/arg": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
+      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA=="
+    },
+    "node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
+    },
+    "node_modules/brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/buffer-from": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
+      "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A=="
+    },
+    "node_modules/concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="
+    },
+    "node_modules/create-require": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
+      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ=="
+    },
+    "node_modules/diff": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
+    "node_modules/es6-promise": {
+      "version": "4.2.8",
+      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
+      "integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w=="
+    },
+    "node_modules/fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw=="
+    },
+    "node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/glob/node_modules/minimatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
+      "dependencies": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+    },
+    "node_modules/isomorphic-fetch": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-3.0.0.tgz",
+      "integrity": "sha512-qvUtwJ3j6qwsF3jLxkZ72qCgjMysPzDfeV240JHiGZsANBYd+EEuu35v7dfrJ9Up0Ak07D7GGSkGhCHTqg/5wA==",
+      "dependencies": {
+        "node-fetch": "^2.6.1",
+        "whatwg-fetch": "^3.4.1"
+      }
+    },
+    "node_modules/jsonc-parser": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.2.0.tgz",
+      "integrity": "sha512-gfFQZrcTc8CnKXp6Y4/CBT3fTc0OVuDofpre4aEeEpSBPV5X5v4+Vmx+8snU7RLPrNHPKSgLxGo9YuQzz20o+w=="
+    },
+    "node_modules/lunr": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/lunr/-/lunr-2.3.9.tgz",
+      "integrity": "sha512-zTU3DaZaF3Rt9rhN3uBMGQD3dD2/vFQqnvZCDv4dl5iOzq2IZQqTxu90r4E5J+nP70J3ilqVCrbho2eWaeW8Ow=="
+    },
+    "node_modules/make-error": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw=="
+    },
+    "node_modules/marked": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-4.3.0.tgz",
+      "integrity": "sha512-PRsaiG84bK+AMvxziE/lCFss8juXjNaWzVbN5tXAm4XjeaS9NAHhop+PjQxz2A9h8Q4M/xGmzP8vqNwy6JeK0A==",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
+      "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/minimatch/node_modules/brace-expansion": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.5.1.tgz",
+      "integrity": "sha512-vBZcPRUR5MZJwoyi3ZoyQlc1rXeEck8KgeC9AwwOn+exuxLxq5toTRDTSaVrXHxelDMHy9zlicw8u66yxoSUFg==",
+      "bin": {
+        "prettier": "bin-prettier.js"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/shiki": {
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/shiki/-/shiki-0.10.1.tgz",
+      "integrity": "sha512-VsY7QJVzU51j5o1+DguUd+6vmCmZ5v/6gYu4vyYAhzjuNQU6P/vmSy4uQaOhvje031qQMiW0d2BwgMH52vqMng==",
+      "dependencies": {
+        "jsonc-parser": "^3.0.0",
+        "vscode-oniguruma": "^1.6.1",
+        "vscode-textmate": "5.2.0"
+      }
+    },
+    "node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/source-map-support": {
+      "version": "0.5.19",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.19.tgz",
+      "integrity": "sha512-Wonm7zOCIJzBGQdB+thsPar0kYuCIzYvxZwlBa87yi/Mdjv7Tip2cyVbLj5o0cFPN4EVkuTwb3GDDyUx2DGnGw==",
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "source-map": "^0.6.0"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
+    },
+    "node_modules/ts-node": {
+      "version": "9.1.1",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-9.1.1.tgz",
+      "integrity": "sha512-hPlt7ZACERQGf03M253ytLY3dHbGNGrAq9qIHWUY9XHYl1z7wYngSr3OQ5xmui8o2AaxsONxIzjafLUiWBo1Fg==",
+      "dependencies": {
+        "arg": "^4.1.0",
+        "create-require": "^1.1.0",
+        "diff": "^4.0.1",
+        "make-error": "^1.1.1",
+        "source-map-support": "^0.5.17",
+        "yn": "3.1.1"
+      },
+      "bin": {
+        "ts-node": "dist/bin.js",
+        "ts-node-script": "dist/bin-script.js",
+        "ts-node-transpile-only": "dist/bin-transpile.js",
+        "ts-script": "dist/bin-script-deprecated.js"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=2.7"
+      }
+    },
+    "node_modules/typedoc": {
+      "version": "0.22.15",
+      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.22.15.tgz",
+      "integrity": "sha512-CMd1lrqQbFvbx6S9G6fL4HKp3GoIuhujJReWqlIvSb2T26vGai+8Os3Mde7Pn832pXYemd9BMuuYWhFpL5st0Q==",
+      "dependencies": {
+        "glob": "^7.2.0",
+        "lunr": "^2.3.9",
+        "marked": "^4.0.12",
+        "minimatch": "^5.0.1",
+        "shiki": "^0.10.1"
+      },
+      "bin": {
+        "typedoc": "bin/typedoc"
+      },
+      "engines": {
+        "node": ">= 12.10.0"
+      },
+      "peerDependencies": {
+        "typescript": "4.0.x || 4.1.x || 4.2.x || 4.3.x || 4.4.x || 4.5.x || 4.6.x"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.1.3.tgz",
+      "integrity": "sha512-B3ZIOf1IKeH2ixgHhj6la6xdwR9QrLC5d1VKeCSY4tvkqhF2eqd9O7txNlS0PO3GrBAFIdr3L1ndNwteUbZLYg==",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=4.2.0"
+      }
+    },
+    "node_modules/url-join": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/url-join/-/url-join-4.0.1.tgz",
+      "integrity": "sha512-jk1+QP6ZJqyOiuEI9AEWQfju/nB2Pw466kbA0LEZljHwKeMgd9WrAEgEGxjPDD2+TNbbb37rTyhEfrCXfuKXnA=="
+    },
+    "node_modules/vscode-oniguruma": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/vscode-oniguruma/-/vscode-oniguruma-1.7.0.tgz",
+      "integrity": "sha512-L9WMGRfrjOhgHSdOYgCt/yRMsXzLDJSL7BPrOZt73gU0iWO4mpqzqQzOz5srxqTvMBaR0XZTSrVWo4j55Rc6cA=="
+    },
+    "node_modules/vscode-textmate": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/vscode-textmate/-/vscode-textmate-5.2.0.tgz",
+      "integrity": "sha512-Uw5ooOQxRASHgu6C7GVvUxisKXfSgW4oFlO+aa+PAkgmH89O3CXxEEzNRNtHSqtXFTl0nAC1uYj0GMSH27uwtQ=="
+    },
+    "node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
+    },
+    "node_modules/whatwg-fetch": {
+      "version": "3.6.19",
+      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.6.19.tgz",
+      "integrity": "sha512-d67JP4dHSbm2TrpFj8AbO8DnL1JXL5J9u0Kq2xW6d0TFDbCA3Muhdt8orXC22utleTVj7Prqt82baN6RBvnEgw=="
+    },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
+    },
+    "node_modules/yn": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
+      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
+      "engines": {
+        "node": ">=6"
+      }
+    }
+  },
   "dependencies": {
     "@bitmovin/api-sdk": {
       "version": "1.174.0",

--- a/javascript/package-lock.json
+++ b/javascript/package-lock.json
@@ -1,346 +1,17 @@
 {
   "name": "bitmovin-typescript-examples",
   "version": "1.0.0",
-  "lockfileVersion": 2,
+  "lockfileVersion": 1,
   "requires": true,
-  "packages": {
-    "": {
-      "name": "bitmovin-typescript-examples",
-      "version": "1.0.0",
-      "license": "MIT",
-      "dependencies": {
-        "@bitmovin/api-sdk": "^1.118.0",
-        "@types/node": "^14.14.20",
-        "prettier": "^2.5.1",
-        "ts-node": "^9.1.1",
-        "typescript": "^4.1.3"
-      }
-    },
-    "node_modules/@bitmovin/api-sdk": {
-      "version": "1.120.0",
-      "resolved": "https://registry.npmjs.org/@bitmovin/api-sdk/-/api-sdk-1.120.0.tgz",
-      "integrity": "sha512-t0GqxyhqR90nyR+mm3Xe2bZ6DgFLJEeU1ROLcCcYV0cksDXu9TT21mSB8xf+A7FHgNsFEcLM/lNzYNEUWaX1/g==",
-      "dependencies": {
-        "es6-promise": "^4.2.5",
-        "isomorphic-fetch": ">=3.0.0",
-        "typedoc": "^0.22.15",
-        "url-join": "^4.0.0"
-      }
-    },
-    "node_modules/@types/node": {
-      "version": "14.14.20",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.20.tgz",
-      "integrity": "sha512-Y93R97Ouif9JEOWPIUyU+eyIdyRqQR0I8Ez1dzku4hDx34NWh4HbtIc3WNzwB1Y9ULvNGeu5B8h8bVL5cAk4/A=="
-    },
-    "node_modules/arg": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
-      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA=="
-    },
-    "node_modules/balanced-match": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
-    },
-    "node_modules/brace-expansion": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
-      "dependencies": {
-        "balanced-match": "^1.0.0"
-      }
-    },
-    "node_modules/buffer-from": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
-      "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A=="
-    },
-    "node_modules/create-require": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
-      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ=="
-    },
-    "node_modules/diff": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
-      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
-      "engines": {
-        "node": ">=0.3.1"
-      }
-    },
-    "node_modules/es6-promise": {
-      "version": "4.2.8",
-      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
-      "integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w=="
-    },
-    "node_modules/fs.realpath": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw=="
-    },
-    "node_modules/glob": {
-      "version": "8.0.3",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-8.0.3.tgz",
-      "integrity": "sha512-ull455NHSHI/Y1FqGaaYFaLGkNMMJbavMrEGFXG/PGrg6y7sutWHUHrz6gy6WEBH6akM1M414dWKCNs+IhKdiQ==",
-      "dependencies": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^5.0.1",
-        "once": "^1.3.0"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/inflight": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
-      "dependencies": {
-        "once": "^1.3.0",
-        "wrappy": "1"
-      }
-    },
-    "node_modules/inherits": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
-    },
-    "node_modules/isomorphic-fetch": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-3.0.0.tgz",
-      "integrity": "sha512-qvUtwJ3j6qwsF3jLxkZ72qCgjMysPzDfeV240JHiGZsANBYd+EEuu35v7dfrJ9Up0Ak07D7GGSkGhCHTqg/5wA==",
-      "dependencies": {
-        "node-fetch": "^2.6.1",
-        "whatwg-fetch": "^3.4.1"
-      }
-    },
-    "node_modules/jsonc-parser": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.0.0.tgz",
-      "integrity": "sha512-fQzRfAbIBnR0IQvftw9FJveWiHp72Fg20giDrHz6TdfB12UH/uue0D3hm57UB5KgAVuniLMCaS8P1IMj9NR7cA=="
-    },
-    "node_modules/lunr": {
-      "version": "2.3.9",
-      "resolved": "https://registry.npmjs.org/lunr/-/lunr-2.3.9.tgz",
-      "integrity": "sha512-zTU3DaZaF3Rt9rhN3uBMGQD3dD2/vFQqnvZCDv4dl5iOzq2IZQqTxu90r4E5J+nP70J3ilqVCrbho2eWaeW8Ow=="
-    },
-    "node_modules/make-error": {
-      "version": "1.3.6",
-      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
-      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw=="
-    },
-    "node_modules/marked": {
-      "version": "4.0.17",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-4.0.17.tgz",
-      "integrity": "sha512-Wfk0ATOK5iPxM4ptrORkFemqroz0ZDxp5MWfYA7H/F+wO17NRWV5Ypxi6p3g2Xmw2bKeiYOl6oVnLHKxBA0VhA==",
-      "bin": {
-        "marked": "bin/marked.js"
-      },
-      "engines": {
-        "node": ">= 12"
-      }
-    },
-    "node_modules/minimatch": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.0.tgz",
-      "integrity": "sha512-9TPBGGak4nHfGZsPBohm9AWg6NoT7QTCehS3BIJABslyZbzxfV78QM2Y6+i741OPZIafFAaiiEMh5OyIrJPgtg==",
-      "dependencies": {
-        "brace-expansion": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/node-fetch": {
-      "version": "2.6.7",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
-      "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
-      "dependencies": {
-        "whatwg-url": "^5.0.0"
-      },
-      "engines": {
-        "node": "4.x || >=6.0.0"
-      },
-      "peerDependencies": {
-        "encoding": "^0.1.0"
-      },
-      "peerDependenciesMeta": {
-        "encoding": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/once": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
-      "dependencies": {
-        "wrappy": "1"
-      }
-    },
-    "node_modules/prettier": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.5.1.tgz",
-      "integrity": "sha512-vBZcPRUR5MZJwoyi3ZoyQlc1rXeEck8KgeC9AwwOn+exuxLxq5toTRDTSaVrXHxelDMHy9zlicw8u66yxoSUFg==",
-      "bin": {
-        "prettier": "bin-prettier.js"
-      },
-      "engines": {
-        "node": ">=10.13.0"
-      }
-    },
-    "node_modules/shiki": {
-      "version": "0.10.1",
-      "resolved": "https://registry.npmjs.org/shiki/-/shiki-0.10.1.tgz",
-      "integrity": "sha512-VsY7QJVzU51j5o1+DguUd+6vmCmZ5v/6gYu4vyYAhzjuNQU6P/vmSy4uQaOhvje031qQMiW0d2BwgMH52vqMng==",
-      "dependencies": {
-        "jsonc-parser": "^3.0.0",
-        "vscode-oniguruma": "^1.6.1",
-        "vscode-textmate": "5.2.0"
-      }
-    },
-    "node_modules/source-map": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/source-map-support": {
-      "version": "0.5.19",
-      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.19.tgz",
-      "integrity": "sha512-Wonm7zOCIJzBGQdB+thsPar0kYuCIzYvxZwlBa87yi/Mdjv7Tip2cyVbLj5o0cFPN4EVkuTwb3GDDyUx2DGnGw==",
-      "dependencies": {
-        "buffer-from": "^1.0.0",
-        "source-map": "^0.6.0"
-      }
-    },
-    "node_modules/tr46": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-      "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o="
-    },
-    "node_modules/ts-node": {
-      "version": "9.1.1",
-      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-9.1.1.tgz",
-      "integrity": "sha512-hPlt7ZACERQGf03M253ytLY3dHbGNGrAq9qIHWUY9XHYl1z7wYngSr3OQ5xmui8o2AaxsONxIzjafLUiWBo1Fg==",
-      "dependencies": {
-        "arg": "^4.1.0",
-        "create-require": "^1.1.0",
-        "diff": "^4.0.1",
-        "make-error": "^1.1.1",
-        "source-map-support": "^0.5.17",
-        "yn": "3.1.1"
-      },
-      "bin": {
-        "ts-node": "dist/bin.js",
-        "ts-node-script": "dist/bin-script.js",
-        "ts-node-transpile-only": "dist/bin-transpile.js",
-        "ts-script": "dist/bin-script-deprecated.js"
-      },
-      "engines": {
-        "node": ">=10.0.0"
-      },
-      "peerDependencies": {
-        "typescript": ">=2.7"
-      }
-    },
-    "node_modules/typedoc": {
-      "version": "0.22.17",
-      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.22.17.tgz",
-      "integrity": "sha512-h6+uXHVVCPDaANzjwzdsj9aePBjZiBTpiMpBBeyh1zcN2odVsDCNajz8zyKnixF93HJeGpl34j/70yoEE5BfNg==",
-      "dependencies": {
-        "glob": "^8.0.3",
-        "lunr": "^2.3.9",
-        "marked": "^4.0.16",
-        "minimatch": "^5.1.0",
-        "shiki": "^0.10.1"
-      },
-      "bin": {
-        "typedoc": "bin/typedoc"
-      },
-      "engines": {
-        "node": ">= 12.10.0"
-      },
-      "peerDependencies": {
-        "typescript": "4.0.x || 4.1.x || 4.2.x || 4.3.x || 4.4.x || 4.5.x || 4.6.x || 4.7.x"
-      }
-    },
-    "node_modules/typescript": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.1.3.tgz",
-      "integrity": "sha512-B3ZIOf1IKeH2ixgHhj6la6xdwR9QrLC5d1VKeCSY4tvkqhF2eqd9O7txNlS0PO3GrBAFIdr3L1ndNwteUbZLYg==",
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=4.2.0"
-      }
-    },
-    "node_modules/url-join": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/url-join/-/url-join-4.0.1.tgz",
-      "integrity": "sha512-jk1+QP6ZJqyOiuEI9AEWQfju/nB2Pw466kbA0LEZljHwKeMgd9WrAEgEGxjPDD2+TNbbb37rTyhEfrCXfuKXnA=="
-    },
-    "node_modules/vscode-oniguruma": {
-      "version": "1.6.2",
-      "resolved": "https://registry.npmjs.org/vscode-oniguruma/-/vscode-oniguruma-1.6.2.tgz",
-      "integrity": "sha512-KH8+KKov5eS/9WhofZR8M8dMHWN2gTxjMsG4jd04YhpbPR91fUj7rYQ2/XjeHCJWbg7X++ApRIU9NUwM2vTvLA=="
-    },
-    "node_modules/vscode-textmate": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/vscode-textmate/-/vscode-textmate-5.2.0.tgz",
-      "integrity": "sha512-Uw5ooOQxRASHgu6C7GVvUxisKXfSgW4oFlO+aa+PAkgmH89O3CXxEEzNRNtHSqtXFTl0nAC1uYj0GMSH27uwtQ=="
-    },
-    "node_modules/webidl-conversions": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-      "integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE="
-    },
-    "node_modules/whatwg-fetch": {
-      "version": "3.6.2",
-      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.6.2.tgz",
-      "integrity": "sha512-bJlen0FcuU/0EMLrdbJ7zOnW6ITZLrZMIarMUVmdKtsGvZna8vxKYaexICWPfZ8qwf9fzNq+UEIZrnSaApt6RA=="
-    },
-    "node_modules/whatwg-url": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
-      "integrity": "sha1-lmRU6HZUYuN2RNNib2dCzotwll0=",
-      "dependencies": {
-        "tr46": "~0.0.3",
-        "webidl-conversions": "^3.0.0"
-      }
-    },
-    "node_modules/wrappy": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
-    },
-    "node_modules/yn": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
-      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
-      "engines": {
-        "node": ">=6"
-      }
-    }
-  },
   "dependencies": {
     "@bitmovin/api-sdk": {
-      "version": "1.120.0",
-      "resolved": "https://registry.npmjs.org/@bitmovin/api-sdk/-/api-sdk-1.120.0.tgz",
-      "integrity": "sha512-t0GqxyhqR90nyR+mm3Xe2bZ6DgFLJEeU1ROLcCcYV0cksDXu9TT21mSB8xf+A7FHgNsFEcLM/lNzYNEUWaX1/g==",
+      "version": "1.174.0",
+      "resolved": "https://registry.npmjs.org/@bitmovin/api-sdk/-/api-sdk-1.174.0.tgz",
+      "integrity": "sha512-q+3KUgoqvAKVLJTk+TxtFb6NXSBGWCdo9knkqOSPJj9L256NvE4FJuIaYd07fPiN5U1pnexnJFd+gmBWZrNefA==",
       "requires": {
         "es6-promise": "^4.2.5",
         "isomorphic-fetch": ">=3.0.0",
-        "typedoc": "^0.22.15",
+        "typedoc": "0.22.15",
         "url-join": "^4.0.0"
       }
     },
@@ -360,17 +31,23 @@
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
     },
     "brace-expansion": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
       "requires": {
-        "balanced-match": "^1.0.0"
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
       }
     },
     "buffer-from": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
       "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A=="
+    },
+    "concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="
     },
     "create-require": {
       "version": "1.1.1",
@@ -393,15 +70,26 @@
       "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw=="
     },
     "glob": {
-      "version": "8.0.3",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-8.0.3.tgz",
-      "integrity": "sha512-ull455NHSHI/Y1FqGaaYFaLGkNMMJbavMrEGFXG/PGrg6y7sutWHUHrz6gy6WEBH6akM1M414dWKCNs+IhKdiQ==",
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
       "requires": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
         "inherits": "2",
-        "minimatch": "^5.0.1",
-        "once": "^1.3.0"
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "dependencies": {
+        "minimatch": {
+          "version": "3.1.2",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+          "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+          "requires": {
+            "brace-expansion": "^1.1.7"
+          }
+        }
       }
     },
     "inflight": {
@@ -428,9 +116,9 @@
       }
     },
     "jsonc-parser": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.0.0.tgz",
-      "integrity": "sha512-fQzRfAbIBnR0IQvftw9FJveWiHp72Fg20giDrHz6TdfB12UH/uue0D3hm57UB5KgAVuniLMCaS8P1IMj9NR7cA=="
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.2.0.tgz",
+      "integrity": "sha512-gfFQZrcTc8CnKXp6Y4/CBT3fTc0OVuDofpre4aEeEpSBPV5X5v4+Vmx+8snU7RLPrNHPKSgLxGo9YuQzz20o+w=="
     },
     "lunr": {
       "version": "2.3.9",
@@ -443,22 +131,32 @@
       "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw=="
     },
     "marked": {
-      "version": "4.0.17",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-4.0.17.tgz",
-      "integrity": "sha512-Wfk0ATOK5iPxM4ptrORkFemqroz0ZDxp5MWfYA7H/F+wO17NRWV5Ypxi6p3g2Xmw2bKeiYOl6oVnLHKxBA0VhA=="
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-4.3.0.tgz",
+      "integrity": "sha512-PRsaiG84bK+AMvxziE/lCFss8juXjNaWzVbN5tXAm4XjeaS9NAHhop+PjQxz2A9h8Q4M/xGmzP8vqNwy6JeK0A=="
     },
     "minimatch": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.0.tgz",
-      "integrity": "sha512-9TPBGGak4nHfGZsPBohm9AWg6NoT7QTCehS3BIJABslyZbzxfV78QM2Y6+i741OPZIafFAaiiEMh5OyIrJPgtg==",
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
+      "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
       "requires": {
         "brace-expansion": "^2.0.1"
+      },
+      "dependencies": {
+        "brace-expansion": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+          "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+          "requires": {
+            "balanced-match": "^1.0.0"
+          }
+        }
       }
     },
     "node-fetch": {
-      "version": "2.6.7",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
-      "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
       "requires": {
         "whatwg-url": "^5.0.0"
       }
@@ -470,6 +168,11 @@
       "requires": {
         "wrappy": "1"
       }
+    },
+    "path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg=="
     },
     "prettier": {
       "version": "2.5.1",
@@ -503,7 +206,7 @@
     "tr46": {
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-      "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o="
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
     },
     "ts-node": {
       "version": "9.1.1",
@@ -519,14 +222,14 @@
       }
     },
     "typedoc": {
-      "version": "0.22.17",
-      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.22.17.tgz",
-      "integrity": "sha512-h6+uXHVVCPDaANzjwzdsj9aePBjZiBTpiMpBBeyh1zcN2odVsDCNajz8zyKnixF93HJeGpl34j/70yoEE5BfNg==",
+      "version": "0.22.15",
+      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.22.15.tgz",
+      "integrity": "sha512-CMd1lrqQbFvbx6S9G6fL4HKp3GoIuhujJReWqlIvSb2T26vGai+8Os3Mde7Pn832pXYemd9BMuuYWhFpL5st0Q==",
       "requires": {
-        "glob": "^8.0.3",
+        "glob": "^7.2.0",
         "lunr": "^2.3.9",
-        "marked": "^4.0.16",
-        "minimatch": "^5.1.0",
+        "marked": "^4.0.12",
+        "minimatch": "^5.0.1",
         "shiki": "^0.10.1"
       }
     },
@@ -541,9 +244,9 @@
       "integrity": "sha512-jk1+QP6ZJqyOiuEI9AEWQfju/nB2Pw466kbA0LEZljHwKeMgd9WrAEgEGxjPDD2+TNbbb37rTyhEfrCXfuKXnA=="
     },
     "vscode-oniguruma": {
-      "version": "1.6.2",
-      "resolved": "https://registry.npmjs.org/vscode-oniguruma/-/vscode-oniguruma-1.6.2.tgz",
-      "integrity": "sha512-KH8+KKov5eS/9WhofZR8M8dMHWN2gTxjMsG4jd04YhpbPR91fUj7rYQ2/XjeHCJWbg7X++ApRIU9NUwM2vTvLA=="
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/vscode-oniguruma/-/vscode-oniguruma-1.7.0.tgz",
+      "integrity": "sha512-L9WMGRfrjOhgHSdOYgCt/yRMsXzLDJSL7BPrOZt73gU0iWO4mpqzqQzOz5srxqTvMBaR0XZTSrVWo4j55Rc6cA=="
     },
     "vscode-textmate": {
       "version": "5.2.0",
@@ -553,17 +256,17 @@
     "webidl-conversions": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-      "integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE="
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
     },
     "whatwg-fetch": {
-      "version": "3.6.2",
-      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.6.2.tgz",
-      "integrity": "sha512-bJlen0FcuU/0EMLrdbJ7zOnW6ITZLrZMIarMUVmdKtsGvZna8vxKYaexICWPfZ8qwf9fzNq+UEIZrnSaApt6RA=="
+      "version": "3.6.19",
+      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.6.19.tgz",
+      "integrity": "sha512-d67JP4dHSbm2TrpFj8AbO8DnL1JXL5J9u0Kq2xW6d0TFDbCA3Muhdt8orXC22utleTVj7Prqt82baN6RBvnEgw=="
     },
     "whatwg-url": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
-      "integrity": "sha1-lmRU6HZUYuN2RNNib2dCzotwll0=",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
       "requires": {
         "tr46": "~0.0.3",
         "webidl-conversions": "^3.0.0"

--- a/javascript/package.json
+++ b/javascript/package.json
@@ -17,7 +17,7 @@
   "author": "Bitmovin Inc",
   "license": "MIT",
   "dependencies": {
-    "@bitmovin/api-sdk": "^1.118.0",
+    "@bitmovin/api-sdk": "^1.174.0",
     "@types/node": "^14.14.20",
     "prettier": "^2.5.1",
     "ts-node": "^9.1.1",

--- a/javascript/src/RtmpLiveHdEncoding.ts
+++ b/javascript/src/RtmpLiveHdEncoding.ts
@@ -1,0 +1,482 @@
+import ConfigProvider from '../common/ConfigProvider';
+import {join} from 'path';
+import BitmovinApi, {
+  AacAudioConfiguration,
+  AclEntry,
+  AclPermission,
+  CodecConfiguration,
+  ConsoleLogger,
+  DashManifestDefault,
+  DashManifestDefaultVersion,
+  Encoding,
+  EncodingOutput,
+  Fmp4Muxing,
+  H264VideoConfiguration,
+  HlsManifestDefault,
+  HlsManifestDefaultVersion,
+  Input,
+  LiveAutoShutdownConfiguration,
+  LiveDashManifest,
+  LiveEncoding,
+  LiveHlsManifest,
+  MessageType,
+  MuxingStream,
+  Output,
+  PresetConfiguration,
+  RtmpInput,
+  S3Output,
+  StartLiveChannelEncodingRequest,
+  Status,
+  Stream,
+  StreamInput,
+  StreamSelectionMode,
+  Task
+} from '@bitmovin/api-sdk';
+
+/**
+ * This example shows how to configure and start a live encoding using default DASH and HLS
+ * manifests. For more information see: https://bitmovin.com/live-encoding-live-streaming/
+ *
+ * <p>The following configuration parameters are expected:
+ *
+ * <ul>
+ *   <li>BITMOVIN_API_KEY - Your API key for the Bitmovin API
+ *   <li>BITMOVIN_TENANT_ORG_ID - (optional) The ID of the Organisation in which you want to perform the encoding.
+ *   <li>S3_OUTPUT_BUCKET_NAME - The name of your S3 output bucket. Example: my-bucket-name
+ *   <li>S3_OUTPUT_ACCESS_KEY - The access key of your S3 output bucket
+ *   <li>S3_OUTPUT_SECRET_KEY - The secret key of your S3 output bucket
+ *   <li>S3_OUTPUT_BASE_PATH - The base path on your S3 output bucket where content will be written.
+ *       Example: /outputs
+ * </ul>
+ *
+ * <p>Configuration parameters will be retrieved from these sources in the listed order: *
+ *
+ * <ol>
+ *   <li>command line arguments (eg BITMOVIN_API_KEY=xyz)
+ *   <li>properties file located in the root folder of the JAVA examples at ./examples.properties
+ *       (see examples.properties.template as reference)
+ *   <li>environment variables
+ *   <li>properties file located in the home folder at ~/.bitmovin/examples.properties (see
+ *       examples.properties.template as reference)
+ * </ol>
+ */
+
+const exampleName = 'RtmpLiveHdEncoding';
+const streamKey = 'myStreamKey';
+
+/**
+ * Make sure to set the correct resolution of your input video, so the aspect ratio can be
+ * calculated.
+ */
+const inputVideoWidth = 1920;
+const inputVideoHeight = 1080;
+const aspectRatio = inputVideoWidth / inputVideoHeight;
+
+const maxMinutesToWaitForLiveEncodingDetails = 5;
+const maxMinutesToWaitForEncodingStatus = 5;
+
+/**
+ * Automatically shutdown the live stream if there is no input anymore for a predefined number of seconds.
+ */
+const bytesReadTimeoutSeconds = 3600; // 1 hour
+
+/**
+ * Automatically shutdown the live stream after a predefined runtime in minutes.
+ */
+const streamTimeoutMinutes = 12 * 60; // 12 hours
+
+const configProvider: ConfigProvider = new ConfigProvider();
+const bitmovinApi = new BitmovinApi({
+  apiKey: configProvider.getBitmovinApiKey(),
+  // uncomment the following line if you are working with a multi-tenant account
+  // tenantOrgId: configProvider.getBitmovinTenantOrgId(),
+  logger: new ConsoleLogger()
+});
+
+async function main() {
+  const encoding: Encoding = await createEncoding(exampleName, 'Live encoding with RTMP input');
+
+  const input: RtmpInput = await getRtmpInput();
+  const output = await createS3Output(
+    configProvider.getS3OutputBucketName(),
+    configProvider.getS3OutputAccessKey(),
+    configProvider.getS3OutputSecretKey()
+  );
+
+  const h264VideoConfiguration = await createH264VideoConfig(1080, 3000000);
+  const aacAudioConfiguration = await createAacAudioConfig(128000);
+
+  const videoStream = await createStream(encoding, input, 'live', h264VideoConfiguration);
+  const audioStream = await createStream(encoding, input, 'live', aacAudioConfiguration);
+
+  await createFmp4Muxing(encoding, output, `/video/${h264VideoConfiguration.height}p`, videoStream);
+  await createFmp4Muxing(encoding, output, `/audio/${aacAudioConfiguration.bitrate! / 1000}kbps`, audioStream);
+
+  const dashManifest: DashManifestDefault = await createDefaultDashManifest(encoding, output, '/');
+  const hlsManifest: HlsManifestDefault = await createDefaultHlsManifest(encoding, output, '/');
+
+  const liveDashManifest = new LiveDashManifest({
+    manifestId: dashManifest.id
+  });
+
+  const liveHlsManifest = new LiveHlsManifest({
+    manifestId: hlsManifest.id
+  });
+
+  /*
+  Setting the autoShutdownConfiguration is optional,
+  if omitted the live encoding will not shut down automatically.
+  */
+  const autoShutdownConfiguration = new LiveAutoShutdownConfiguration({
+    bytesReadTimeoutSeconds: bytesReadTimeoutSeconds,
+    streamTimeoutMinutes: streamTimeoutMinutes
+  });
+
+  const startLiveEncodingRequest = new StartLiveChannelEncodingRequest({
+    dashManifests: [liveDashManifest],
+    hlsManifests: [liveHlsManifest],
+    autoShutdownConfiguration: autoShutdownConfiguration,
+    streamKey: streamKey
+  });
+
+  await startLiveEncodingAndWaitUntilRunning(encoding, startLiveEncodingRequest);
+  const liveEncoding: LiveEncoding = await waitForLiveEncodingDetails(encoding);
+
+  console.log('Live encoding started successfully and is ready for streaming', liveEncoding);
+}
+
+/**
+ * Periodically checks the status of the encoding.
+ *
+ * <p>Note: You can also use our webhooks API instead of polling the status. For more information
+ * checkout the API spec:
+ * https://bitmovin.com/docs/encoding/api-reference/sections/notifications-webhooks
+ *
+ * <p>API endpoint:
+ * https://bitmovin.com/docs/encoding/api-reference/sections/encodings#/Encoding/GetEncodingEncodingsStatusByEncodingId
+ *
+ * @param encoding The encoding that should have the expected status
+ * @param expectedStatus The expected status the provided encoding should have. See {@link Status}
+ */
+async function waitUntilEncodingIsInState(encoding: Encoding, expectedStatus: Status) {
+  const checkIntervalInSeconds = 5;
+  const maxAttempts = maxMinutesToWaitForEncodingStatus * (60 / checkIntervalInSeconds);
+  let attempt = 0;
+
+  let task: Task;
+  do {
+    task = await bitmovinApi.encoding.encodings.status(encoding.id!);
+    if (task.status === expectedStatus) {
+      return;
+    }
+    if (task.status === Status.ERROR) {
+      logTaskErrors(task);
+      throw new Error('Encoding failed');
+    }
+    console.log(
+      `Encoding status is ${task.status}. Waiting for status ${expectedStatus} (${attempt} / ${maxAttempts})`
+    );
+    await timeout(checkIntervalInSeconds * 1000);
+  } while (attempt++ < maxAttempts);
+  throw new Error(
+    `Encoding did not switch to state ${expectedStatus} within ${maxMinutesToWaitForEncodingStatus} minutes. Aborting.`
+  );
+}
+
+/**
+ * This method starts the live encoding with HD option
+ *
+ * <p>API endpoint:
+ * https://bitmovin.com/docs/encoding/api-reference/sections/encodings#/Encoding/PostEncodingEncodingsLiveStartByEncodingId
+ *
+ * @param encoding The encoding that should be started and checked until it is running
+ * @param startLiveEncodingRequest The request object that is sent with the start call
+ */
+async function startLiveEncodingAndWaitUntilRunning(
+  encoding: Encoding,
+  startLiveEncodingRequest: StartLiveChannelEncodingRequest
+) {
+  await bitmovinApi.encoding.encodings.live.hd.start(encoding.id!, startLiveEncodingRequest);
+  return waitUntilEncodingIsInState(encoding, Status.RUNNING);
+}
+
+/**
+ * Tries to get the live details of the encoding. It could take a few minutes until this info is
+ * available.
+ *
+ * <p>API endpoint:
+ * https://bitmovin.com/docs/encoding/api-reference/sections/encodings#/Encoding/GetEncodingEncodingsLiveByEncodingId
+ *
+ * @param encoding The encoding for which the live encoding details should be retrieved
+ */
+async function waitForLiveEncodingDetails(encoding: Encoding): Promise<LiveEncoding> {
+  const timeoutIntervalSeconds = 5;
+  let retries = 0;
+  const maxRetries = (60 / timeoutIntervalSeconds) * maxMinutesToWaitForLiveEncodingDetails;
+
+  do {
+    try {
+      return await bitmovinApi.encoding.encodings.live.get(encoding.id!);
+    } catch (e) {
+      console.log(`Failed to fetch live encoding details. Retrying... ${retries} / ${maxRetries}`);
+      retries++;
+      await timeout(timeoutIntervalSeconds * 1000);
+    }
+  } while (retries < maxRetries);
+  throw new Error(`Live encoding details could not be fetched after ${maxMinutesToWaitForLiveEncodingDetails} minutes`);
+}
+
+/**
+ * Creates an Encoding object. This is the base object to configure your encoding.
+ *
+ * <p>API endpoint:
+ * https://bitmovin.com/docs/encoding/api-reference/sections/encodings#/Encoding/PostEncodingEncodings
+ *
+ * @param name A name that will help you identify the encoding in our dashboard (required)
+ * @param description A description of the encoding (optional)
+ */
+function createEncoding(name: string, description: string): Promise<Encoding> {
+  const encoding = new Encoding({
+    name: name,
+    description: description
+  });
+
+  return bitmovinApi.encoding.encodings.create(encoding);
+}
+
+/**
+ * Creates a resource representing an AWS S3 cloud storage bucket to which generated content will
+ * be transferred. For alternative output methods see <a
+ * href="https://bitmovin.com/docs/encoding/articles/supported-input-output-storages">list of
+ * supported input and output storages</a>
+ *
+ * <p>The provided credentials need to allow <i>read</i>, <i>write</i> and <i>list</i> operations.
+ * <i>delete</i> should also be granted to allow overwriting of existings files. See <a
+ * href="https://bitmovin.com/docs/encoding/faqs/how-do-i-create-a-aws-s3-bucket-which-can-be-used-as-output-location">creating
+ * an S3 bucket and setting permissions</a> for further information
+ *
+ * <p>For reasons of simplicity, a new output resource is created on each execution of this
+ * example. In production use, this method should be replaced by a <a
+ * href="https://bitmovin.com/docs/encoding/api-reference/sections/outputs#/Encoding/GetEncodingOutputsS3">get
+ * call</a> retrieving an existing resource.
+ *
+ * <p>API endpoint:
+ * https://bitmovin.com/docs/encoding/api-reference/sections/outputs#/Encoding/PostEncodingOutputsS3
+ *
+ * @param bucketName The name of the S3 bucket
+ * @param accessKey The access key of your S3 account
+ * @param secretKey The secret key of your S3 account
+ */
+function createS3Output(bucketName: string, accessKey: string, secretKey: string): Promise<S3Output> {
+  const s3Output = new S3Output({
+    bucketName: bucketName,
+    accessKey: accessKey,
+    secretKey: secretKey
+  });
+
+  return bitmovinApi.encoding.outputs.s3.create(s3Output);
+}
+
+/**
+ * Retrieves the first RTMP input. This is an automatically generated resource and read-only.
+ *
+ * <p>API endpoint:
+ * https://bitmovin.com/docs/encoding/api-reference/sections/inputs#/Encoding/GetEncodingInputsRtmp
+ */
+async function getRtmpInput(): Promise<RtmpInput> {
+  const resp = await bitmovinApi.encoding.inputs.rtmp.list();
+  return resp.items![0];
+}
+
+/**
+ * Builds an EncodingOutput object which defines where the output content (e.g. of a muxing) will
+ * be written to. Public read permissions will be set for the files written, so they can be
+ * accessed easily via HTTP.
+ *
+ * @param output The output resource to be used by the EncodingOutput
+ * @param outputPath The path where the content will be written to
+ */
+function buildEncodingOutput(output: Output, outputPath: string): EncodingOutput {
+  const aclEntry = new AclEntry({
+    permission: AclPermission.PUBLIC_READ
+  });
+
+  return new EncodingOutput({
+    outputPath: buildAbsolutePath(outputPath),
+    outputId: output.id,
+    acl: [aclEntry]
+  });
+}
+
+/**
+ * Builds an absolute path by concatenating the S3_OUTPUT_BASE_PATH configuration parameter, the
+ * name of this example and the given relative path
+ *
+ * <p>e.g.: /s3/base/path/exampleName/relative/path
+ *
+ * @param relativePath The relative path that is concatenated
+ * @return The absolute path
+ */
+function buildAbsolutePath(relativePath: string): string {
+  return join(configProvider.getS3OutputBasePath(), exampleName, relativePath);
+}
+
+/**
+ * Creates a configuration for the H.264 video codec to be applied to video streams.
+ *
+ * <p>The output resolution is defined by setting the height to 1080 pixels. Width will be
+ * determined automatically to maintain the aspect ratio of your input video.
+ *
+ * <p>To keep things simple, we use a quality-optimized Live preset configuration, which will apply
+ * proven settings for the codec. See <a
+ * href="https://bitmovin.com/docs/encoding/tutorials/how-to-optimize-your-h264-codec-configuration-for-different-use-cases">How
+ * to optimize your H264 codec configuration for different use-cases</a> for alternative presets.
+ *
+ * <p>API endpoint:
+ * https://bitmovin.com/docs/encoding/api-reference/sections/configurations#/Encoding/PostEncodingConfigurationsVideoH264
+ */
+function createH264VideoConfig(height: number, bitrate: number): Promise<H264VideoConfiguration> {
+  const config = new H264VideoConfiguration({
+    name: `H.264 ${height}p ${bitrate / (1000 * 1000)} Mbit/s`,
+    presetConfiguration: PresetConfiguration.LIVE_STANDARD,
+    height,
+    width: Math.ceil(aspectRatio * height),
+    bitrate
+  });
+
+  return bitmovinApi.encoding.configurations.video.h264.create(config);
+}
+
+/**
+ * Creates a configuration for the AAC audio codec to be applied to audio streams.
+ *
+ * <p>API endpoint:
+ * https://bitmovin.com/docs/encoding/api-reference/sections/configurations#/Encoding/PostEncodingConfigurationsAudioAac
+ */
+function createAacAudioConfig(bitrate): Promise<AacAudioConfiguration> {
+  const config = new AacAudioConfiguration({
+    name: `AAC ${bitrate / 1000} kbit/s`,
+    bitrate
+  });
+
+  return bitmovinApi.encoding.configurations.audio.aac.create(config);
+}
+
+/**
+ * Adds a video or audio stream to an encoding
+ *
+ * <p>API endpoint:
+ * https://bitmovin.com/docs/encoding/api-reference/sections/encodings#/Encoding/PostEncodingEncodingsStreamsByEncodingId
+ *
+ * @param encoding The encoding to which the stream will be added
+ * @param input The input resource providing the input file
+ * @param inputPath The path to the input file
+ * @param codecConfiguration The codec configuration to be applied to the stream
+ */
+function createStream(
+  encoding: Encoding,
+  input: Input,
+  inputPath: string,
+  codecConfiguration: CodecConfiguration
+): Promise<Stream> {
+  const streamInput = new StreamInput({
+    inputId: input.id,
+    inputPath: inputPath,
+    selectionMode: StreamSelectionMode.AUTO,
+  });
+
+  const stream = new Stream({
+    inputStreams: [streamInput],
+    codecConfigId: codecConfiguration.id
+  });
+
+  return bitmovinApi.encoding.encodings.streams.create(encoding.id!, stream);
+}
+
+/**
+ * Creates a DASH default manifest that automatically includes all representations configured in
+ * the encoding.
+ *
+ * <p>API endpoint:
+ * https://bitmovin.com/docs/encoding/api-reference/sections/manifests#/Encoding/PostEncodingManifestsDash
+ *
+ * @param encoding The encoding for which the manifest should be generated
+ * @param output The output where the manifest should be written to
+ * @param outputPath The path to which the manifest should be written
+ */
+function createDefaultDashManifest(
+  encoding: Encoding,
+  output: Output,
+  outputPath: string
+): Promise<DashManifestDefault> {
+  let dashManifestDefault = new DashManifestDefault({
+    encodingId: encoding.id,
+    manifestName: 'stream.mpd',
+    version: DashManifestDefaultVersion.V1,
+    outputs: [buildEncodingOutput(output, outputPath)]
+  });
+
+  return bitmovinApi.encoding.manifests.dash.default.create(dashManifestDefault);
+}
+
+/**
+ * Creates an HLS default manifest that automatically includes all representations configured in
+ * the encoding.
+ *
+ * <p>API endpoint:
+ * https://bitmovin.com/docs/encoding/api-reference/sections/manifests#/Encoding/PostEncodingManifestsHlsDefault
+ *
+ * @param encoding The encoding for which the manifest should be generated
+ * @param output The output to which the manifest should be written
+ * @param outputPath The path to which the manifest should be written
+ */
+function createDefaultHlsManifest(encoding: Encoding, output: Output, outputPath: string): Promise<HlsManifestDefault> {
+  let hlsManifestDefault = new HlsManifestDefault({
+    encodingId: encoding.id,
+    outputs: [buildEncodingOutput(output, outputPath)],
+    name: 'master.m3u8',
+    version: HlsManifestDefaultVersion.V1
+  });
+
+  return bitmovinApi.encoding.manifests.hls.default.create(hlsManifestDefault);
+}
+
+/**
+ * Creates a fragmented MP4 muxing. This will generate segments with a given segment length for
+ * adaptive streaming.
+ *
+ * <p>API endpoint:
+ * https://bitmovin.com/docs/encoding/api-reference/all#/Encoding/PostEncodingEncodingsMuxingsFmp4ByEncodingId
+ *
+ * @param encoding The encoding where to add the muxing to
+ * @param output The output that should be used for the muxing to write the segments to
+ * @param outputPath The output path where the fragmented segments will be written to
+ * @param stream The stream to be muxed
+ */
+function createFmp4Muxing(encoding: Encoding, output: Output, outputPath: string, stream: Stream): Promise<Fmp4Muxing> {
+  const muxingStream = new MuxingStream({
+    streamId: stream.id
+  });
+
+  const muxing = new Fmp4Muxing({
+    outputs: [buildEncodingOutput(output, outputPath)],
+    streams: [muxingStream],
+    segmentLength: 4
+  });
+
+  return bitmovinApi.encoding.encodings.muxings.fmp4.create(encoding.id!, muxing);
+}
+
+function logTaskErrors(task: Task): void {
+  if (task == undefined) {
+    return;
+  }
+
+  task.messages!.filter(msg => msg.type === MessageType.ERROR).forEach(msg => console.error(msg.text));
+}
+
+function timeout(ms: number): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+main();

--- a/php/composer.json
+++ b/php/composer.json
@@ -9,6 +9,6 @@
     ],
     "require": {
         "php": ">=7.1.0",
-        "bitmovin/bitmovin-api-sdk-php": "1.103.0"
+        "bitmovin/bitmovin-api-sdk-php": "1.174.0"
     }
 }

--- a/php/composer.lock
+++ b/php/composer.lock
@@ -4,30 +4,30 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "b260d50097a156b8d8cd7878769301fa",
+    "content-hash": "2be68b33ecd99e2a1c3218b6ff97844b",
     "packages": [
         {
             "name": "bitmovin/bitmovin-api-sdk-php",
-            "version": "1.103.0",
+            "version": "1.174.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/bitmovin/bitmovin-api-sdk-php.git",
-                "reference": "5141663b95618c07eb3a6c9c74c0ebf35eebdb88"
+                "reference": "d70b99f8c17237b23c87c03d32f5c7794f712d94"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/bitmovin/bitmovin-api-sdk-php/zipball/5141663b95618c07eb3a6c9c74c0ebf35eebdb88",
-                "reference": "5141663b95618c07eb3a6c9c74c0ebf35eebdb88",
+                "url": "https://api.github.com/repos/bitmovin/bitmovin-api-sdk-php/zipball/d70b99f8c17237b23c87c03d32f5c7794f712d94",
+                "reference": "d70b99f8c17237b23c87c03d32f5c7794f712d94",
                 "shasum": ""
             },
             "require": {
                 "ext-json": "*",
-                "guzzlehttp/guzzle": "^6.3 || ^7.3",
-                "nesbot/carbon": "^2.48",
+                "guzzlehttp/guzzle": "^7.3 || ^7.4.2",
+                "nesbot/carbon": "^2.57",
                 "php": "^7.1 || ^8.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^7.5 || ^8.5 || ^9.3"
+                "phpunit/phpunit": "^8.5 || ^9.3"
             },
             "type": "library",
             "autoload": {
@@ -46,26 +46,30 @@
                 }
             ],
             "description": "This is the Bitmovin API SDK for PHP",
-            "time": "2021-07-27T09:05:05+00:00"
+            "support": {
+                "issues": "https://github.com/bitmovin/bitmovin-api-sdk-php/issues",
+                "source": "https://github.com/bitmovin/bitmovin-api-sdk-php/tree/v1.174.0"
+            },
+            "time": "2023-09-26T15:46:21+00:00"
         },
         {
             "name": "guzzlehttp/guzzle",
-            "version": "7.4.5",
+            "version": "7.8.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/guzzle.git",
-                "reference": "1dd98b0564cb3f6bd16ce683cb755f94c10fbd82"
+                "reference": "1110f66a6530a40fe7aea0378fe608ee2b2248f9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/1dd98b0564cb3f6bd16ce683cb755f94c10fbd82",
-                "reference": "1dd98b0564cb3f6bd16ce683cb755f94c10fbd82",
+                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/1110f66a6530a40fe7aea0378fe608ee2b2248f9",
+                "reference": "1110f66a6530a40fe7aea0378fe608ee2b2248f9",
                 "shasum": ""
             },
             "require": {
                 "ext-json": "*",
-                "guzzlehttp/promises": "^1.5",
-                "guzzlehttp/psr7": "^1.9 || ^2.4",
+                "guzzlehttp/promises": "^1.5.3 || ^2.0.1",
+                "guzzlehttp/psr7": "^1.9.1 || ^2.5.1",
                 "php": "^7.2.5 || ^8.0",
                 "psr/http-client": "^1.0",
                 "symfony/deprecation-contracts": "^2.2 || ^3.0"
@@ -74,10 +78,11 @@
                 "psr/http-client-implementation": "1.0"
             },
             "require-dev": {
-                "bamarni/composer-bin-plugin": "^1.4.1",
+                "bamarni/composer-bin-plugin": "^1.8.1",
                 "ext-curl": "*",
-                "php-http/client-integration-tests": "^3.0",
-                "phpunit/phpunit": "^8.5.5 || ^9.3.5",
+                "php-http/client-integration-tests": "dev-master#2c025848417c1135031fdf9c728ee53d0a7ceaee as 3.0.999",
+                "php-http/message-factory": "^1.1",
+                "phpunit/phpunit": "^8.5.29 || ^9.5.23",
                 "psr/log": "^1.1 || ^2.0 || ^3.0"
             },
             "suggest": {
@@ -87,8 +92,9 @@
             },
             "type": "library",
             "extra": {
-                "branch-alias": {
-                    "dev-master": "7.4-dev"
+                "bamarni-bin": {
+                    "bin-links": true,
+                    "forward-command": false
                 }
             },
             "autoload": {
@@ -154,7 +160,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/guzzle/issues",
-                "source": "https://github.com/guzzle/guzzle/tree/7.4.5"
+                "source": "https://github.com/guzzle/guzzle/tree/7.8.0"
             },
             "funding": [
                 {
@@ -170,38 +176,37 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-06-20T22:16:13+00:00"
+            "time": "2023-08-27T10:20:53+00:00"
         },
         {
             "name": "guzzlehttp/promises",
-            "version": "1.5.1",
+            "version": "2.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/promises.git",
-                "reference": "fe752aedc9fd8fcca3fe7ad05d419d32998a06da"
+                "reference": "111166291a0f8130081195ac4556a5587d7f1b5d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/promises/zipball/fe752aedc9fd8fcca3fe7ad05d419d32998a06da",
-                "reference": "fe752aedc9fd8fcca3fe7ad05d419d32998a06da",
+                "url": "https://api.github.com/repos/guzzle/promises/zipball/111166291a0f8130081195ac4556a5587d7f1b5d",
+                "reference": "111166291a0f8130081195ac4556a5587d7f1b5d",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.5"
+                "php": "^7.2.5 || ^8.0"
             },
             "require-dev": {
-                "symfony/phpunit-bridge": "^4.4 || ^5.1"
+                "bamarni/composer-bin-plugin": "^1.8.1",
+                "phpunit/phpunit": "^8.5.29 || ^9.5.23"
             },
             "type": "library",
             "extra": {
-                "branch-alias": {
-                    "dev-master": "1.5-dev"
+                "bamarni-bin": {
+                    "bin-links": true,
+                    "forward-command": false
                 }
             },
             "autoload": {
-                "files": [
-                    "src/functions_include.php"
-                ],
                 "psr-4": {
                     "GuzzleHttp\\Promise\\": "src/"
                 }
@@ -238,7 +243,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/promises/issues",
-                "source": "https://github.com/guzzle/promises/tree/1.5.1"
+                "source": "https://github.com/guzzle/promises/tree/2.0.1"
             },
             "funding": [
                 {
@@ -254,26 +259,26 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-10-22T20:56:57+00:00"
+            "time": "2023-08-03T15:11:55+00:00"
         },
         {
             "name": "guzzlehttp/psr7",
-            "version": "2.4.0",
+            "version": "2.6.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/psr7.git",
-                "reference": "13388f00956b1503577598873fffb5ae994b5737"
+                "reference": "be45764272e8873c72dbe3d2edcfdfcc3bc9f727"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/psr7/zipball/13388f00956b1503577598873fffb5ae994b5737",
-                "reference": "13388f00956b1503577598873fffb5ae994b5737",
+                "url": "https://api.github.com/repos/guzzle/psr7/zipball/be45764272e8873c72dbe3d2edcfdfcc3bc9f727",
+                "reference": "be45764272e8873c72dbe3d2edcfdfcc3bc9f727",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.2.5 || ^8.0",
                 "psr/http-factory": "^1.0",
-                "psr/http-message": "^1.0",
+                "psr/http-message": "^1.1 || ^2.0",
                 "ralouphie/getallheaders": "^3.0"
             },
             "provide": {
@@ -281,17 +286,18 @@
                 "psr/http-message-implementation": "1.0"
             },
             "require-dev": {
-                "bamarni/composer-bin-plugin": "^1.4.1",
+                "bamarni/composer-bin-plugin": "^1.8.1",
                 "http-interop/http-factory-tests": "^0.9",
-                "phpunit/phpunit": "^8.5.8 || ^9.3.10"
+                "phpunit/phpunit": "^8.5.29 || ^9.5.23"
             },
             "suggest": {
                 "laminas/laminas-httphandlerrunner": "Emit PSR-7 responses"
             },
             "type": "library",
             "extra": {
-                "branch-alias": {
-                    "dev-master": "2.4-dev"
+                "bamarni-bin": {
+                    "bin-links": true,
+                    "forward-command": false
                 }
             },
             "autoload": {
@@ -353,7 +359,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/psr7/issues",
-                "source": "https://github.com/guzzle/psr7/tree/2.4.0"
+                "source": "https://github.com/guzzle/psr7/tree/2.6.1"
             },
             "funding": [
                 {
@@ -369,36 +375,44 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-06-20T21:43:11+00:00"
+            "time": "2023-08-27T10:13:57+00:00"
         },
         {
             "name": "nesbot/carbon",
-            "version": "2.50.0",
+            "version": "2.71.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/briannesbitt/Carbon.git",
-                "reference": "f47f17d17602b2243414a44ad53d9f8b9ada5fdb"
+                "reference": "98276233188583f2ff845a0f992a235472d9466a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/briannesbitt/Carbon/zipball/f47f17d17602b2243414a44ad53d9f8b9ada5fdb",
-                "reference": "f47f17d17602b2243414a44ad53d9f8b9ada5fdb",
+                "url": "https://api.github.com/repos/briannesbitt/Carbon/zipball/98276233188583f2ff845a0f992a235472d9466a",
+                "reference": "98276233188583f2ff845a0f992a235472d9466a",
                 "shasum": ""
             },
             "require": {
                 "ext-json": "*",
                 "php": "^7.1.8 || ^8.0",
+                "psr/clock": "^1.0",
                 "symfony/polyfill-mbstring": "^1.0",
-                "symfony/translation": "^3.4 || ^4.0 || ^5.0"
+                "symfony/polyfill-php80": "^1.16",
+                "symfony/translation": "^3.4 || ^4.0 || ^5.0 || ^6.0"
+            },
+            "provide": {
+                "psr/clock-implementation": "1.0"
             },
             "require-dev": {
+                "doctrine/dbal": "^2.0 || ^3.1.4",
                 "doctrine/orm": "^2.7",
-                "friendsofphp/php-cs-fixer": "^2.14 || ^3.0",
+                "friendsofphp/php-cs-fixer": "^3.0",
                 "kylekatarnls/multi-tester": "^2.0",
+                "ondrejmirtes/better-reflection": "*",
                 "phpmd/phpmd": "^2.9",
                 "phpstan/extension-installer": "^1.0",
-                "phpstan/phpstan": "^0.12.54",
-                "phpunit/phpunit": "^7.5.20 || ^8.5.14",
+                "phpstan/phpstan": "^0.12.99 || ^1.7.14",
+                "phpunit/php-file-iterator": "^2.0.5 || ^3.0.6",
+                "phpunit/phpunit": "^7.5.20 || ^8.5.26 || ^9.5.20",
                 "squizlabs/php_codesniffer": "^3.4"
             },
             "bin": [
@@ -407,8 +421,8 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.x-dev",
-                    "dev-3.x": "3.x-dev"
+                    "dev-3.x": "3.x-dev",
+                    "dev-master": "2.x-dev"
                 },
                 "laravel": {
                     "providers": [
@@ -448,25 +462,92 @@
                 "datetime",
                 "time"
             ],
-            "time": "2021-06-28T22:38:45+00:00"
+            "support": {
+                "docs": "https://carbon.nesbot.com/docs",
+                "issues": "https://github.com/briannesbitt/Carbon/issues",
+                "source": "https://github.com/briannesbitt/Carbon"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sponsors/kylekatarnls",
+                    "type": "github"
+                },
+                {
+                    "url": "https://opencollective.com/Carbon#sponsor",
+                    "type": "opencollective"
+                },
+                {
+                    "url": "https://tidelift.com/subscription/pkg/packagist-nesbot-carbon?utm_source=packagist-nesbot-carbon&utm_medium=referral&utm_campaign=readme",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2023-09-25T11:31:05+00:00"
         },
         {
-            "name": "psr/http-client",
-            "version": "1.0.1",
+            "name": "psr/clock",
+            "version": "1.0.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/php-fig/http-client.git",
-                "reference": "2dfb5f6c5eff0e91e20e913f8c5452ed95b86621"
+                "url": "https://github.com/php-fig/clock.git",
+                "reference": "e41a24703d4560fd0acb709162f73b8adfc3aa0d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/http-client/zipball/2dfb5f6c5eff0e91e20e913f8c5452ed95b86621",
-                "reference": "2dfb5f6c5eff0e91e20e913f8c5452ed95b86621",
+                "url": "https://api.github.com/repos/php-fig/clock/zipball/e41a24703d4560fd0acb709162f73b8adfc3aa0d",
+                "reference": "e41a24703d4560fd0acb709162f73b8adfc3aa0d",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.0 || ^8.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Clock\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "https://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interface for reading the clock.",
+            "homepage": "https://github.com/php-fig/clock",
+            "keywords": [
+                "clock",
+                "now",
+                "psr",
+                "psr-20",
+                "time"
+            ],
+            "support": {
+                "issues": "https://github.com/php-fig/clock/issues",
+                "source": "https://github.com/php-fig/clock/tree/1.0.0"
+            },
+            "time": "2022-11-25T14:36:26+00:00"
+        },
+        {
+            "name": "psr/http-client",
+            "version": "1.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/http-client.git",
+                "reference": "bb5906edc1c324c9a05aa0873d40117941e5fa90"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/http-client/zipball/bb5906edc1c324c9a05aa0873d40117941e5fa90",
+                "reference": "bb5906edc1c324c9a05aa0873d40117941e5fa90",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.0 || ^8.0",
-                "psr/http-message": "^1.0"
+                "psr/http-message": "^1.0 || ^2.0"
             },
             "type": "library",
             "extra": {
@@ -486,7 +567,7 @@
             "authors": [
                 {
                     "name": "PHP-FIG",
-                    "homepage": "http://www.php-fig.org/"
+                    "homepage": "https://www.php-fig.org/"
                 }
             ],
             "description": "Common interface for HTTP clients",
@@ -498,27 +579,27 @@
                 "psr-18"
             ],
             "support": {
-                "source": "https://github.com/php-fig/http-client/tree/master"
+                "source": "https://github.com/php-fig/http-client"
             },
-            "time": "2020-06-29T06:28:15+00:00"
+            "time": "2023-09-23T14:17:50+00:00"
         },
         {
             "name": "psr/http-factory",
-            "version": "1.0.1",
+            "version": "1.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-fig/http-factory.git",
-                "reference": "12ac7fcd07e5b077433f5f2bee95b3a771bf61be"
+                "reference": "e616d01114759c4c489f93b099585439f795fe35"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/http-factory/zipball/12ac7fcd07e5b077433f5f2bee95b3a771bf61be",
-                "reference": "12ac7fcd07e5b077433f5f2bee95b3a771bf61be",
+                "url": "https://api.github.com/repos/php-fig/http-factory/zipball/e616d01114759c4c489f93b099585439f795fe35",
+                "reference": "e616d01114759c4c489f93b099585439f795fe35",
                 "shasum": ""
             },
             "require": {
                 "php": ">=7.0.0",
-                "psr/http-message": "^1.0"
+                "psr/http-message": "^1.0 || ^2.0"
             },
             "type": "library",
             "extra": {
@@ -538,7 +619,7 @@
             "authors": [
                 {
                     "name": "PHP-FIG",
-                    "homepage": "http://www.php-fig.org/"
+                    "homepage": "https://www.php-fig.org/"
                 }
             ],
             "description": "Common interfaces for PSR-7 HTTP message factories",
@@ -553,31 +634,31 @@
                 "response"
             ],
             "support": {
-                "source": "https://github.com/php-fig/http-factory/tree/master"
+                "source": "https://github.com/php-fig/http-factory/tree/1.0.2"
             },
-            "time": "2019-04-30T12:38:16+00:00"
+            "time": "2023-04-10T20:10:41+00:00"
         },
         {
             "name": "psr/http-message",
-            "version": "1.0.1",
+            "version": "2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-fig/http-message.git",
-                "reference": "f6561bf28d520154e4b0ec72be95418abe6d9363"
+                "reference": "402d35bcb92c70c026d1a6a9883f06b2ead23d71"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/http-message/zipball/f6561bf28d520154e4b0ec72be95418abe6d9363",
-                "reference": "f6561bf28d520154e4b0ec72be95418abe6d9363",
+                "url": "https://api.github.com/repos/php-fig/http-message/zipball/402d35bcb92c70c026d1a6a9883f06b2ead23d71",
+                "reference": "402d35bcb92c70c026d1a6a9883f06b2ead23d71",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.0"
+                "php": "^7.2 || ^8.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.0.x-dev"
+                    "dev-master": "2.0.x-dev"
                 }
             },
             "autoload": {
@@ -592,7 +673,7 @@
             "authors": [
                 {
                     "name": "PHP-FIG",
-                    "homepage": "http://www.php-fig.org/"
+                    "homepage": "https://www.php-fig.org/"
                 }
             ],
             "description": "Common interface for HTTP messages",
@@ -606,9 +687,9 @@
                 "response"
             ],
             "support": {
-                "source": "https://github.com/php-fig/http-message/tree/master"
+                "source": "https://github.com/php-fig/http-message/tree/2.0"
             },
-            "time": "2016-08-06T14:39:51+00:00"
+            "time": "2023-04-04T09:54:51+00:00"
         },
         {
             "name": "ralouphie/getallheaders",
@@ -656,25 +737,25 @@
         },
         {
             "name": "symfony/deprecation-contracts",
-            "version": "v2.5.1",
+            "version": "v3.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/deprecation-contracts.git",
-                "reference": "e8b495ea28c1d97b5e0c121748d6f9b53d075c66"
+                "reference": "7c3aff79d10325257a001fcf92d991f24fc967cf"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/e8b495ea28c1d97b5e0c121748d6f9b53d075c66",
-                "reference": "e8b495ea28c1d97b5e0c121748d6f9b53d075c66",
+                "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/7c3aff79d10325257a001fcf92d991f24fc967cf",
+                "reference": "7c3aff79d10325257a001fcf92d991f24fc967cf",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.1"
+                "php": ">=8.1"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "2.5-dev"
+                    "dev-main": "3.4-dev"
                 },
                 "thanks": {
                     "name": "symfony/contracts",
@@ -703,7 +784,7 @@
             "description": "A generic function and convention to trigger deprecation notices",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/deprecation-contracts/tree/v2.5.1"
+                "source": "https://github.com/symfony/deprecation-contracts/tree/v3.3.0"
             },
             "funding": [
                 {
@@ -719,20 +800,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-01-02T09:53:40+00:00"
+            "time": "2023-05-23T14:45:45+00:00"
         },
         {
             "name": "symfony/polyfill-mbstring",
-            "version": "v1.26.0",
+            "version": "v1.28.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-mbstring.git",
-                "reference": "9344f9cb97f3b19424af1a21a3b0e75b0a7d8d7e"
+                "reference": "42292d99c55abe617799667f454222c54c60e229"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/9344f9cb97f3b19424af1a21a3b0e75b0a7d8d7e",
-                "reference": "9344f9cb97f3b19424af1a21a3b0e75b0a7d8d7e",
+                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/42292d99c55abe617799667f454222c54c60e229",
+                "reference": "42292d99c55abe617799667f454222c54c60e229",
                 "shasum": ""
             },
             "require": {
@@ -747,7 +828,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "1.26-dev"
+                    "dev-main": "1.28-dev"
                 },
                 "thanks": {
                     "name": "symfony/polyfill",
@@ -786,7 +867,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.26.0"
+                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.28.0"
             },
             "funding": [
                 {
@@ -802,20 +883,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-05-24T11:49:31+00:00"
+            "time": "2023-07-28T09:04:16+00:00"
         },
         {
             "name": "symfony/polyfill-php80",
-            "version": "v1.23.0",
+            "version": "v1.28.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php80.git",
-                "reference": "eca0bf41ed421bed1b57c4958bab16aa86b757d0"
+                "reference": "6caa57379c4aec19c0a12a38b59b26487dcfe4b5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php80/zipball/eca0bf41ed421bed1b57c4958bab16aa86b757d0",
-                "reference": "eca0bf41ed421bed1b57c4958bab16aa86b757d0",
+                "url": "https://api.github.com/repos/symfony/polyfill-php80/zipball/6caa57379c4aec19c0a12a38b59b26487dcfe4b5",
+                "reference": "6caa57379c4aec19c0a12a38b59b26487dcfe4b5",
                 "shasum": ""
             },
             "require": {
@@ -824,7 +905,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "1.23-dev"
+                    "dev-main": "1.28-dev"
                 },
                 "thanks": {
                     "name": "symfony/polyfill",
@@ -832,12 +913,12 @@
                 }
             },
             "autoload": {
-                "psr-4": {
-                    "Symfony\\Polyfill\\Php80\\": ""
-                },
                 "files": [
                     "bootstrap.php"
                 ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Php80\\": ""
+                },
                 "classmap": [
                     "Resources/stubs"
                 ]
@@ -868,55 +949,72 @@
                 "portable",
                 "shim"
             ],
-            "time": "2021-02-19T12:13:01+00:00"
+            "support": {
+                "source": "https://github.com/symfony/polyfill-php80/tree/v1.28.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2023-01-26T09:26:14+00:00"
         },
         {
             "name": "symfony/translation",
-            "version": "v5.3.4",
+            "version": "v6.3.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/translation.git",
-                "reference": "d89ad7292932c2699cbe4af98d72c5c6bbc504c1"
+                "reference": "3ed078c54bc98bbe4414e1e9b2d5e85ed5a5c8bd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/translation/zipball/d89ad7292932c2699cbe4af98d72c5c6bbc504c1",
-                "reference": "d89ad7292932c2699cbe4af98d72c5c6bbc504c1",
+                "url": "https://api.github.com/repos/symfony/translation/zipball/3ed078c54bc98bbe4414e1e9b2d5e85ed5a5c8bd",
+                "reference": "3ed078c54bc98bbe4414e1e9b2d5e85ed5a5c8bd",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.2.5",
-                "symfony/deprecation-contracts": "^2.1",
+                "php": ">=8.1",
+                "symfony/deprecation-contracts": "^2.5|^3",
                 "symfony/polyfill-mbstring": "~1.0",
-                "symfony/polyfill-php80": "^1.16",
-                "symfony/translation-contracts": "^2.3"
+                "symfony/translation-contracts": "^2.5|^3.0"
             },
             "conflict": {
-                "symfony/config": "<4.4",
-                "symfony/dependency-injection": "<5.0",
-                "symfony/http-kernel": "<5.0",
-                "symfony/twig-bundle": "<5.0",
-                "symfony/yaml": "<4.4"
+                "symfony/config": "<5.4",
+                "symfony/console": "<5.4",
+                "symfony/dependency-injection": "<5.4",
+                "symfony/http-client-contracts": "<2.5",
+                "symfony/http-kernel": "<5.4",
+                "symfony/service-contracts": "<2.5",
+                "symfony/twig-bundle": "<5.4",
+                "symfony/yaml": "<5.4"
             },
             "provide": {
-                "symfony/translation-implementation": "2.3"
+                "symfony/translation-implementation": "2.3|3.0"
             },
             "require-dev": {
+                "nikic/php-parser": "^4.13",
                 "psr/log": "^1|^2|^3",
-                "symfony/config": "^4.4|^5.0",
-                "symfony/console": "^4.4|^5.0",
-                "symfony/dependency-injection": "^5.0",
-                "symfony/finder": "^4.4|^5.0",
-                "symfony/http-kernel": "^5.0",
-                "symfony/intl": "^4.4|^5.0",
+                "symfony/config": "^5.4|^6.0",
+                "symfony/console": "^5.4|^6.0",
+                "symfony/dependency-injection": "^5.4|^6.0",
+                "symfony/finder": "^5.4|^6.0",
+                "symfony/http-client-contracts": "^2.5|^3.0",
+                "symfony/http-kernel": "^5.4|^6.0",
+                "symfony/intl": "^5.4|^6.0",
                 "symfony/polyfill-intl-icu": "^1.21",
-                "symfony/service-contracts": "^1.1.2|^2",
-                "symfony/yaml": "^4.4|^5.0"
-            },
-            "suggest": {
-                "psr/log-implementation": "To use logging capability in translator",
-                "symfony/config": "",
-                "symfony/yaml": ""
+                "symfony/routing": "^5.4|^6.0",
+                "symfony/service-contracts": "^2.5|^3",
+                "symfony/yaml": "^5.4|^6.0"
             },
             "type": "library",
             "autoload": {
@@ -946,32 +1044,46 @@
             ],
             "description": "Provides tools to internationalize your application",
             "homepage": "https://symfony.com",
-            "time": "2021-07-25T09:39:16+00:00"
+            "support": {
+                "source": "https://github.com/symfony/translation/tree/v6.3.3"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2023-07-31T07:08:24+00:00"
         },
         {
             "name": "symfony/translation-contracts",
-            "version": "v2.4.0",
+            "version": "v3.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/translation-contracts.git",
-                "reference": "95c812666f3e91db75385749fe219c5e494c7f95"
+                "reference": "02c24deb352fb0d79db5486c0c79905a85e37e86"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/translation-contracts/zipball/95c812666f3e91db75385749fe219c5e494c7f95",
-                "reference": "95c812666f3e91db75385749fe219c5e494c7f95",
+                "url": "https://api.github.com/repos/symfony/translation-contracts/zipball/02c24deb352fb0d79db5486c0c79905a85e37e86",
+                "reference": "02c24deb352fb0d79db5486c0c79905a85e37e86",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.2.5"
-            },
-            "suggest": {
-                "symfony/translation-implementation": ""
+                "php": ">=8.1"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "2.4-dev"
+                    "dev-main": "3.4-dev"
                 },
                 "thanks": {
                     "name": "symfony/contracts",
@@ -981,7 +1093,10 @@
             "autoload": {
                 "psr-4": {
                     "Symfony\\Contracts\\Translation\\": ""
-                }
+                },
+                "exclude-from-classmap": [
+                    "/Test/"
+                ]
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -1007,7 +1122,24 @@
                 "interoperability",
                 "standards"
             ],
-            "time": "2021-03-23T23:28:01+00:00"
+            "support": {
+                "source": "https://github.com/symfony/translation-contracts/tree/v3.3.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2023-05-30T17:17:10+00:00"
         }
     ],
     "packages-dev": [],
@@ -1017,8 +1149,8 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": "^7.1"
+        "php": ">=7.1.0"
     },
     "platform-dev": [],
-    "plugin-api-version": "2.3.0"
+    "plugin-api-version": "2.6.0"
 }

--- a/php/src/RtmpLiveHdEncoding.php
+++ b/php/src/RtmpLiveHdEncoding.php
@@ -1,0 +1,533 @@
+<?php
+
+require './vendor/autoload.php';
+
+require_once('./common/ConfigProvider.php');
+
+use BitmovinApiSdk\BitmovinApi;
+use BitmovinApiSdk\Common\BitmovinApiException;
+use BitmovinApiSdk\Common\Logging\ConsoleLogger;
+use BitmovinApiSdk\Configuration;
+use BitmovinApiSdk\Models\AacAudioConfiguration;
+use BitmovinApiSdk\Models\AclEntry;
+use BitmovinApiSdk\Models\AclPermission;
+use BitmovinApiSdk\Models\CodecConfiguration;
+use BitmovinApiSdk\Models\DashManifestDefault;
+use BitmovinApiSdk\Models\DashManifestDefaultVersion;
+use BitmovinApiSdk\Models\Encoding;
+use BitmovinApiSdk\Models\EncodingOutput;
+use BitmovinApiSdk\Models\Fmp4Muxing;
+use BitmovinApiSdk\Models\H264VideoConfiguration;
+use BitmovinApiSdk\Models\HlsManifestDefault;
+use BitmovinApiSdk\Models\HlsManifestDefaultVersion;
+use BitmovinApiSdk\Models\Input;
+use BitmovinApiSdk\Models\LiveAutoShutdownConfiguration;
+use BitmovinApiSdk\Models\LiveDashManifest;
+use BitmovinApiSdk\Models\LiveEncoding;
+use BitmovinApiSdk\Models\LiveHlsManifest;
+use BitmovinApiSdk\Models\MessageType;
+use BitmovinApiSdk\Models\MuxingStream;
+use BitmovinApiSdk\Models\Output;
+use BitmovinApiSdk\Models\PresetConfiguration;
+use BitmovinApiSdk\Models\RtmpInput;
+use BitmovinApiSdk\Models\S3Output;
+use BitmovinApiSdk\Models\StartLiveChannelEncodingRequest;
+use BitmovinApiSdk\Models\Status;
+use BitmovinApiSdk\Models\Stream;
+use BitmovinApiSdk\Models\StreamInput;
+use BitmovinApiSdk\Models\StreamSelectionMode;
+use BitmovinApiSdk\Models\Task;
+
+/**
+ * This example shows how to configure and start a live encoding using default DASH and HLS
+ * manifests. For more information see: https://bitmovin.com/live-encoding-live-streaming/
+ *
+ * <p>The following configuration parameters are expected:
+ *
+ * <ul>
+ *   <li>BITMOVIN_API_KEY - Your API key for the Bitmovin API
+ *   <li>BITMOVIN_TENANT_ORG_ID - (optional) The ID of the Organisation in which you want to perform the encoding.
+ *   <li>S3_OUTPUT_BUCKET_NAME - The name of your S3 output bucket. Example: my-bucket-name
+ *   <li>S3_OUTPUT_ACCESS_KEY - The access key of your S3 output bucket
+ *   <li>S3_OUTPUT_SECRET_KEY - The secret key of your S3 output bucket
+ *   <li>S3_OUTPUT_BASE_PATH - The base path on your S3 output bucket where content will be written.
+ *       Example: /outputs
+ * </ul>
+ *
+ * <p>Configuration parameters will be retrieved from these sources in the listed order: *
+ *
+ * <ol>
+ *   <li>command line arguments (eg BITMOVIN_API_KEY=xyz)
+ *   <li>properties file located in the root folder of the PHP examples at ./examples.properties
+ *       (see examples.properties.template as reference)
+ *   <li>environment variables
+ *   <li>properties file located in the home folder at ~/.bitmovin/examples.properties (see
+ *       examples.properties.template as reference)
+ * </ol>
+ */
+
+$exampleName = 'RtmpLiveHDEncoding';
+const STREAM_KEY = 'myStreamKey';
+
+/**
+ * Make sure to set the correct resolution of your input video, so the aspect ratio can be
+ * calculated.
+ */
+const INPUT_VIDEO_WIDTH = 1920;
+const INPUT_VIDEO_HEIGHT = 1080;
+const ASPECT_RATIO = INPUT_VIDEO_WIDTH / INPUT_VIDEO_HEIGHT;
+
+const MAX_MINUTES_TO_WAIT_FOR_LIVE_ENCODING_DETAILS = 5;
+const MAX_MINUTES_TO_WAIT_FOR_ENCOIDING_STATUS = 5;
+
+/**
+ * Automatically shutdown the live stream if there is no input anymore for a predefined number of seconds.
+ */
+const BYTES_READ_TIMEOUT_SECONDS = 3600; // 1 hour
+
+/**
+ * Automatically shutdown the live stream after a predefined runtime in minutes.
+ */
+const STREAM_TIMEOUT_MINUTES = 12 * 60; // 12 hours
+
+$configProvider = new ConfigProvider();
+
+try {
+    $bitmovinApi = new BitmovinApi(
+        Configuration::create()
+            ->apiKey($configProvider->getBitmovinApiKey())
+            // uncomment the following line if you are working with a multi-tenant account
+            // ->tenantOrgId($configProvider->getBitmovinTenantOrgId())        
+            ->logger(new ConsoleLogger())
+    );
+
+    $encoding = createEncoding($exampleName, "Live HD encoding with RTMP input");
+
+    $input = getRtmpInput();
+
+    $output = createS3Output(
+        $configProvider->getS3OutputBucketName(),
+        $configProvider->getS3OutputAccessKey(),
+        $configProvider->getS3OutputSecretKey()
+    );
+
+    $h264Config = createH264Config();
+    $aacConfig = createAacConfig();
+
+    $h264Stream = createStream($encoding, $input, 'live', $h264Config);
+    $aacStream = createStream($encoding, $input, 'live', $aacConfig);
+
+    createFmp4Muxing($encoding, $output, 'video/' . $h264Config->height . 'p', $h264Stream);
+    createFmp4Muxing($encoding, $output, 'audio/' . ($aacConfig->bitrate / 1000) . "kbps", $aacStream);
+
+    $dashManifest = createDefaultDashManifest($encoding, $output, '');
+    $hlsManifest = createDefaultHlsManifest($encoding, $output, '');
+
+    $liveDashManifest = new LiveDashManifest();
+    $liveDashManifest->manifestId($dashManifest->id);
+
+    $liveHlsManifest = new LiveHlsManifest();
+    $liveHlsManifest->manifestId($hlsManifest->id);
+
+    $startLiveEncodingRequest = new StartLiveChannelEncodingRequest();
+    $startLiveEncodingRequest->dashManifests([$liveDashManifest]);
+    $startLiveEncodingRequest->hlsManifests([$liveHlsManifest]);
+    $startLiveEncodingRequest->streamKey(STREAM_KEY);
+
+    /*
+     Setting the autoShutdownConfiguration is optional,
+     if omitted the live encoding will not shut down automatically.
+     */
+    $autoShutdownConfiguration = new LiveAutoShutdownConfiguration();
+    $autoShutdownConfiguration->bytesReadTimeoutSeconds(BYTES_READ_TIMEOUT_SECONDS);
+    $autoShutdownConfiguration->streamTimeoutMinutes(STREAM_TIMEOUT_MINUTES);
+    $startLiveEncodingRequest->autoShutdownConfiguration($autoShutdownConfiguration);
+
+    startLiveEncodingAndWaitUntilRunning($encoding, $startLiveEncodingRequest);
+    $liveEncoding = waitForLiveEncodingDetails($encoding);
+
+    echo "Live encoding is up and ready for ingest. RTMP URL: rtmp://" . $liveEncoding->encoderIp . "/live StreamKey: "
+        . $liveEncoding->streamKey . PHP_EOL;
+
+    /*
+    This will enable you to shut down the live encoding from within your script.
+    In production, it is naturally recommended to stop the encoding by using the Bitmovin dashboard
+    or an independent API call - https://bitmovin.com/docs/encoding/api-reference/sections/encodings#/Encoding/PostEncodingEncodingsLiveStopByEncodingId
+    */
+    echo 'Press Enter to shutdown...';
+    readline();
+
+    $bitmovinApi->encoding->encodings->live->stop($encoding->id);
+    waitUntilEncodingIsInState($encoding, Status::FINISHED());
+} catch (Exception $exception) {
+    echo $exception;
+}
+
+/**
+ * Tries to get the live details of the encoding. It could take a few minutes until this info is
+ * available.
+ *
+ * <p>API endpoint:
+ * https://bitmovin.com/docs/encoding/api-reference/sections/encodings#/Encoding/GetEncodingEncodingsLiveByEncodingId
+ *
+ * @param Encoding $encoding The encoding for which the live encoding details should be retrieved
+ * @return LiveEncoding
+ * @throws Exception
+ */
+function waitForLiveEncodingDetails(Encoding $encoding)
+{
+    global $bitmovinApi;
+
+    echo "Waiting until live encoding details are available (max " . MAX_MINUTES_TO_WAIT_FOR_LIVE_ENCODING_DETAILS . " minutes) ..." . PHP_EOL;
+
+    $checkIntervalInSeconds = 10;
+    $maxAttempts = MAX_MINUTES_TO_WAIT_FOR_LIVE_ENCODING_DETAILS * (60 / $checkIntervalInSeconds);
+    $attempt = 0;
+
+    do {
+        try {
+            return $bitmovinApi->encoding->encodings->live->get($encoding->id);
+        } catch (BitmovinApiException $e) {
+            echo "Failed to fetch live encoding details. Retrying... " . $attempt . "/" . $maxAttempts . PHP_EOL;
+            $attempt++;
+            sleep($checkIntervalInSeconds);
+        }
+    } while ($attempt < $maxAttempts);
+
+    throw new Exception("Failed to retrieve live encoding details within " . MAX_MINUTES_TO_WAIT_FOR_LIVE_ENCODING_DETAILS . " minutes. Aborting.");
+}
+
+/**
+ * This method starts the live encoding with HD option
+ *
+ * <p>API endpoint:
+ * https://bitmovin.com/docs/encoding/api-reference/sections/encodings#/Encoding/PostEncodingEncodingsLiveStartByEncodingId
+ *
+ * @param Encoding $encoding The encoding that should be started and checked until it is running
+ * @param StartLiveChannelEncodingRequest $startLiveEncodingRequest The request object that is sent with the start call
+ * @throws BitmovinApiException
+ */
+function startLiveEncodingAndWaitUntilRunning(Encoding $encoding, StartLiveChannelEncodingRequest $startLiveEncodingRequest)
+{
+    global $bitmovinApi;
+
+    $bitmovinApi->encoding->encodings->live->hd->start($encoding->id, $startLiveEncodingRequest);
+    waitUntilEncodingIsInState($encoding, Status::RUNNING());
+}
+
+/**
+ * Periodically checks the status of the encoding.
+ *
+ * <p>Note: You can also use our webhooks API instead of polling the status. For more information
+ * checkout the API spec:
+ * https://bitmovin.com/docs/encoding/api-reference/sections/notifications-webhooks
+ *
+ * <p>API endpoint:
+ * https://bitmovin.com/docs/encoding/api-reference/sections/encodings#/Encoding/GetEncodingEncodingsStatusByEncodingId
+ *
+ * @param Encoding $encoding The encoding that should have the expected status
+ * @param Status $expectedStatus The expected status the provided encoding should have. See {@link Status}
+ * @throws BitmovinApiException
+ * @throws Exception
+ */
+function waitUntilEncodingIsInState(Encoding $encoding, Status $expectedStatus)
+{
+    global $bitmovinApi;
+
+    echo "Waiting for encoding to have " . $expectedStatus . " (max " . MAX_MINUTES_TO_WAIT_FOR_ENCOIDING_STATUS . " minutes) ..." . PHP_EOL;
+
+    $checkIntervalInSeconds = 5;
+    $maxAttempts = MAX_MINUTES_TO_WAIT_FOR_ENCOIDING_STATUS * (60 / $checkIntervalInSeconds);
+    $attempt = 0;
+
+    do {
+        $task = $bitmovinApi->encoding->encodings->status($encoding->id);
+
+        if ($task->status == Status::ERROR()) {
+            throw new Exception("Error while waiting for encoding with id " . $encoding->id . " to have the status " . $expectedStatus);
+        }
+        if ($task->status == $expectedStatus) {
+            return;
+        }
+        echo "Encoding status is " . $task->status . ". Waiting for status " . $expectedStatus . " (" . $attempt . " / " . $maxAttempts . ")" . PHP_EOL;
+        sleep($checkIntervalInSeconds);
+    } while ($attempt++ < $maxAttempts);
+
+    throw new Exception("Live encoding did not switch to state " . $expectedStatus . " within " . MAX_MINUTES_TO_WAIT_FOR_ENCOIDING_STATUS . " minutes. Aborting.");
+}
+
+/**
+ * @param Encoding $encoding
+ * @param Output $output
+ * @param string $outputPath
+ * @return DashManifestDefault
+ * @throws BitmovinApiException
+ * @throws Exception
+ */
+function createDefaultDashManifest(Encoding $encoding, Output $output, string $outputPath)
+{
+    global $bitmovinApi;
+
+    $dashManifestDefault = new DashManifestDefault();
+    $dashManifestDefault->encodingId($encoding->id);
+    $dashManifestDefault->manifestName('stream.mpd');
+    $dashManifestDefault->version(DashManifestDefaultVersion::V1());
+    $dashManifestDefault->outputs([buildEncodingOutput($output, $outputPath)]);
+
+    return $bitmovinApi->encoding->manifests->dash->default->create($dashManifestDefault);
+}
+
+/**
+ * @param Encoding $encoding
+ * @param Output $output
+ * @param string $outputPath
+ * @return HlsManifestDefault
+ * @throws BitmovinApiException
+ * @throws Exception
+ */
+function createDefaultHlsManifest(Encoding $encoding, Output $output, string $outputPath)
+{
+    global $bitmovinApi;
+
+    $hlsManifestDefault = new HlsManifestDefault();
+    $hlsManifestDefault->encodingId($encoding->id);
+    $hlsManifestDefault->manifestName('master.m3u8');
+    $hlsManifestDefault->version(HlsManifestDefaultVersion::V1());
+    $hlsManifestDefault->outputs([buildEncodingOutput($output, $outputPath)]);
+
+    return $bitmovinApi->encoding->manifests->hls->default->create($hlsManifestDefault);
+}
+
+/**
+ * Creates a fragmented MP4 muxing. This will generate segments with a given segment length for
+ * adaptive streaming.
+ *
+ * <p>API endpoint:
+ * https://bitmovin.com/docs/encoding/api-reference/all#/Encoding/PostEncodingEncodingsMuxingsFmp4ByEncodingId
+ *
+ * @param Encoding $encoding The encoding to add the MP4 muxing to
+ * @param Output $output The output that should be used for the muxing to write the segments to
+ * @param string $outputPath The output path where the fragments will be written to
+ * @param Stream $stream The stream to be muxed
+ * @return Fmp4Muxing
+ * @throws BitmovinApiException
+ * @throws Exception
+ */
+function createFmp4Muxing(Encoding $encoding, Output $output, string $outputPath, Stream $stream)
+{
+    global $bitmovinApi;
+
+    $muxingStream = new MuxingStream();
+    $muxingStream->streamId($stream->id);
+
+    $muxing = new Fmp4Muxing();
+    $muxing->segmentLength(4.0);
+    $muxing->outputs([buildEncodingOutput($output, $outputPath)]);
+    $muxing->streams([$muxingStream]);
+
+    return $bitmovinApi->encoding->encodings->muxings->fmp4->create($encoding->id, $muxing);
+}
+
+/**
+ * Creates a configuration for the H.264 video codec to be applied to video streams.
+ *
+ * <p>The output resolution is defined by setting the height to 1080 pixels. Width will be
+ * determined automatically to maintain the aspect ratio of your input video.
+ *
+ * <p>To keep things simple, we use a quality-optimized Live preset configuration, which will apply
+ * proven settings for the codec. See <a
+ * href="https://bitmovin.com/docs/encoding/tutorials/how-to-optimize-your-h264-codec-configuration-for-different-use-cases">How
+ * to optimize your H264 codec configuration for different use-cases</a> for alternative presets.
+ *
+ * <p>API endpoint:
+ * https://bitmovin.com/docs/encoding/api-reference/sections/configurations#/Encoding/PostEncodingConfigurationsVideoH264
+ *
+ * @return H264VideoConfiguration
+ * @throws BitmovinApiException
+ */
+function createH264Config()
+{
+    global $bitmovinApi;
+
+    $h264Config = new H264VideoConfiguration();
+    $h264Config->name("H.264 1080p 3 Mbit/s");
+    $h264Config->presetConfiguration(PresetConfiguration::LIVE_STANDARD());
+    $h264Config->height(INPUT_VIDEO_HEIGHT);
+    $h264Config->bitrate(3000000);
+    $h264Config->width(ceil(ASPECT_RATIO * INPUT_VIDEO_HEIGHT));
+
+    return $bitmovinApi->encoding->configurations->video->h264->create($h264Config);
+}
+
+/**
+ * Creates a configuration for the AAC audio codec to be applied to audio streams.
+ *
+ * <p>API endpoint:
+ * https://bitmovin.com/docs/encoding/api-reference/sections/configurations#/Encoding/PostEncodingConfigurationsAudioAac
+ * @return AacAudioConfiguration
+ * @throws BitmovinApiException
+ */
+function createAacConfig()
+{
+    global $bitmovinApi;
+
+    $aacConfig = new AacAudioConfiguration();
+    $aacConfig->name("AAC 128 kbit/s");
+    $aacConfig->bitrate(128000);
+
+    return $bitmovinApi->encoding->configurations->audio->aac->create($aacConfig);
+}
+
+/**
+ * Adds a video or audio stream to an encoding
+ *
+ * <p>API endpoint:
+ * https://bitmovin.com/docs/encoding/api-reference/sections/encodings#/Encoding/PostEncodingEncodingsStreamsByEncodingId
+ *
+ * @param Encoding $encoding The encoding to which the stream will be added
+ * @param Input $input The input resource providing the input file
+ * @param string $inputPath The path to the input file
+ * @param CodecConfiguration $codecConfiguration The codec configuration to be applied to the stream
+ * @return Stream
+ * @throws BitmovinApiException
+ */
+function createStream(Encoding $encoding, Input $input, string $inputPath, CodecConfiguration $codecConfiguration)
+{
+    global $bitmovinApi;
+
+    $streamInput = new StreamInput();
+    $streamInput->inputId($input->id);
+    $streamInput->inputPath($inputPath);
+    $streamInput->selectionMode(StreamSelectionMode::AUTO());
+
+    $stream = new Stream();
+    $stream->inputStreams([$streamInput]);
+    $stream->codecConfigId($codecConfiguration->id);
+
+    return $bitmovinApi->encoding->encodings->streams->create($encoding->id, $stream);
+}
+
+/**
+ * Creates a resource representing an AWS S3 cloud storage bucket to which generated content will
+ * be transferred. For alternative output methods see <a
+ * href="https://bitmovin.com/docs/encoding/articles/supported-input-output-storages">list of
+ * supported input and output storages</a>
+ *
+ * <p>The provided credentials need to allow <i>read</i>, <i>write</i> and <i>list</i> operations.
+ * <i>delete</i> should also be granted to allow overwriting of existings files. See <a
+ * href="https://bitmovin.com/docs/encoding/faqs/how-do-i-create-a-aws-s3-bucket-which-can-be-used-as-output-location">creating
+ * an S3 bucket and setting permissions</a> for further information
+ *
+ * <p>For reasons of simplicity, a new output resource is created on each execution of this
+ * example. In production use, this method should be replaced by a <a
+ * href="https://bitmovin.com/docs/encoding/api-reference/sections/outputs#/Encoding/GetEncodingOutputsS3">get
+ * call</a> retrieving an existing resource.
+ *
+ * <p>API endpoint:
+ * https://bitmovin.com/docs/encoding/api-reference/sections/outputs#/Encoding/PostEncodingOutputsS3
+ *
+ * @param string $bucketName The name of the S3 bucket
+ * @param string $accessKey The access key of your S3 account
+ * @param string $secretKey The secret key of your S3 account
+ * @return S3Output
+ * @throws BitmovinApiException
+ */
+function createS3Output(string $bucketName, string $accessKey, string $secretKey)
+{
+    global $bitmovinApi;
+
+    $output = new S3Output();
+    $output->bucketName($bucketName);
+    $output->accessKey($accessKey);
+    $output->secretKey($secretKey);
+
+    return $bitmovinApi->encoding->outputs->s3->create($output);
+}
+
+/**
+ * @return RtmpInput
+ * @throws BitmovinApiException
+ */
+function getRtmpInput()
+{
+    global $bitmovinApi;
+
+    return $bitmovinApi->encoding->inputs->rtmp->list()->items[0];
+}
+
+/**
+ * Creates an Encoding object. This is the base object to configure your encoding.
+ *
+ * <p>API endpoint:
+ * https://bitmovin.com/docs/encoding/api-reference/sections/encodings#/Encoding/PostEncodingEncodings
+ *
+ * @param string $name A name that will help you identify the encoding in our dashboard (required)
+ * @param string $description description A description of the encoding (optional)
+ * @return Encoding
+ * @throws BitmovinApiException
+ */
+function createEncoding(string $name, string $description)
+{
+    global $bitmovinApi;
+
+    $encoding = new Encoding();
+    $encoding->name($name);
+    $encoding->description($description);
+
+    return $bitmovinApi->encoding->encodings->create($encoding);
+}
+
+/**
+ * Builds an EncodingOutput object which defines where the output content (e.g. of a muxing) will
+ * be written to. Public read permissions will be set for the files written, so they can be
+ * accessed easily via HTTP.
+ *
+ * @param Output $output The output resource to be used by the EncodingOutput
+ * @param string $outputPath The path where the content will be written to
+ * @return EncodingOutput
+ * @throws Exception
+ */
+function buildEncodingOutput(Output $output, string $outputPath)
+{
+    $aclEntry = new AclEntry();
+    $aclEntry->permission(AclPermission::PUBLIC_READ());
+
+    $encodingOutput = new EncodingOutput();
+    $encodingOutput->outputPath(buildAbsolutePath($outputPath));
+    $encodingOutput->outputId($output->id);
+    $encodingOutput->acl([$aclEntry]);
+
+    return $encodingOutput;
+}
+
+/**
+ * Builds an absolute path by concatenating the S3_OUTPUT_BASE_PATH configuration parameter, the
+ * name of this example and the given relative path
+ *
+ * <p>e.g.: /s3/base/path/exampleName/relative/path
+ *
+ * @param string $relativePath The relaitve path that is concatenated
+ * @return string
+ * @throws Exception
+ */
+function buildAbsolutePath(string $relativePath)
+{
+    global $exampleName, $configProvider;
+
+    return $configProvider->getS3OutputBasePath() . $exampleName . DIRECTORY_SEPARATOR . trim($relativePath, DIRECTORY_SEPARATOR);
+}
+
+function logTaskErrors(Task $task)
+{
+    if ($task->messages == null) {
+        return;
+    }
+
+    $messages = array_filter($task->messages, function ($msg) {
+        return $msg->type == MessageType::ERROR();
+    });
+
+    foreach ($messages as $message) {
+        echo $message->text . PHP_EOL;
+    }
+}

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -1,1 +1,1 @@
-bitmovin-api-sdk == 1.118.0
+bitmovin-api-sdk == 1.174.0

--- a/python/src/rtmp_live_hd_encoding.py
+++ b/python/src/rtmp_live_hd_encoding.py
@@ -1,0 +1,493 @@
+import math
+
+from bitmovin_api_sdk import AacAudioConfiguration, AclEntry, AclPermission, BitmovinApi, BitmovinApiLogger, \
+    BitmovinError, DashManifestDefault, DashManifestDefaultVersion, Encoding, EncodingOutput, Fmp4Muxing, \
+    H264VideoConfiguration, HlsManifestDefault, HlsManifestDefaultVersion, LiveDashManifest, LiveHlsManifest, \
+    MessageType, MuxingStream, PresetConfiguration, S3Output, StartLiveChannelEncodingRequest, Stream, StreamInput, \
+    StreamSelectionMode, Status, LiveAutoShutdownConfiguration
+
+from common import ConfigProvider
+from os import path
+from time import sleep
+
+"""
+This example shows how to configure and start a live encoding using default DASH and HLS
+manifests. For more information see: https://bitmovin.com/live-encoding-live-streaming/
+
+<p>The following configuration parameters are expected:
+
+<ul>
+  <li>BITMOVIN_API_KEY - Your API key for the Bitmovin API
+  <li>BITMOVIN_TENANT_ORG_ID - (optional) The ID of the Organisation in which you want to perform the encoding.
+  <li>S3_OUTPUT_BUCKET_NAME - The name of your S3 output bucket. Example: my-bucket-name
+  <li>S3_OUTPUT_ACCESS_KEY - The access key of your S3 output bucket
+  <li>S3_OUTPUT_SECRET_KEY - The secret key of your S3 output bucket
+  <li>S3_OUTPUT_BASE_PATH - The base path on your S3 output bucket where content will be written.
+      Example: /outputs
+</ul>
+
+<p>Configuration parameters will be retrieved from these sources in the listed order:
+
+<ol>
+  <li>command line arguments (eg BITMOVIN_API_KEY=xyz)
+  <li>properties file located in the root folder of the JAVA examples at ./examples.properties
+      (see examples.properties.template as reference)
+  <li>environment variables
+  <li>properties file located in the home folder at ~/.bitmovin/examples.properties (see
+      examples.properties.template as reference)
+</ol>
+"""
+
+EXAMPLE_NAME = "RtmpLiveHdEncoding"
+stream_key = "myStreamKey"
+
+input_video_width = 1920
+input_video_height = 1080
+aspect_ratio = input_video_width / input_video_height
+
+max_minutes_to_wait_for_live_encoding_details = 5
+max_minutes_to_wait_for_encoding_status = 5
+
+# Automatically shutdown the live stream if there is no input anymore for a predefined number of seconds.
+bytes_read_timeout_seconds = 3600
+# Automatically shutdown the live stream after a predefined runtime in minutes.
+stream_timeout_minutes = 12 * 60
+
+config_provider = ConfigProvider()
+bitmovin_api = BitmovinApi(api_key=config_provider.get_bitmovin_api_key(),
+                           # uncomment the following line if you are working with a multi-tenant account
+                           # tenant_org_id=config_provider.get_bitmovin_tenant_org_id(),
+                           logger=BitmovinApiLogger())
+
+
+def main():
+    encoding = _create_encoding(name=EXAMPLE_NAME, description="Live HD encoding with RTMP input")
+
+    rtmp_input = _get_rtmp_input()
+    output = _create_s3_output(
+        bucket_name=config_provider.get_s3_output_bucket_name(),
+        access_key=config_provider.get_s3_output_access_key(),
+        secret_key=config_provider.get_s3_output_secret_key()
+    )
+
+    h264_video_configuration = _create_h264_video_configuration(height=input_video_height, bitrate=3000000)
+    aac_audio_configuration = _create_aac_audio_configuration(bitrate=128000)
+
+    h264_video_stream = _create_stream(
+        encoding=encoding,
+        encoding_input=rtmp_input,
+        input_path="live",
+        codec_configuration=h264_video_configuration
+    )
+
+    aac_audio_stream = _create_stream(
+        encoding=encoding,
+        encoding_input=rtmp_input,
+        input_path="live",
+        codec_configuration=aac_audio_configuration
+    )
+
+    _create_fmp4_muxing(encoding=encoding,
+                        output=output,
+                        output_path="video/{0}p".format(h264_video_configuration.height),
+                        stream=h264_video_stream)
+    _create_fmp4_muxing(encoding=encoding,
+                        output=output,
+                        output_path="audio/{0}kbps".format(aac_audio_configuration.bitrate / 1000),
+                        stream=aac_audio_stream)
+
+    dash_manifest = _generate_dash_manifest(
+        encoding=encoding,
+        output=output,
+        output_path=""
+    )
+    hls_manifest = _generate_hls_manifest(
+        encoding=encoding,
+        output=output,
+        output_path=""
+    )
+
+    live_dash_manifest = LiveDashManifest(manifest_id=dash_manifest.id)
+    live_hls_manifest = LiveHlsManifest(manifest_id=hls_manifest.id)
+
+    # Setting the auto_shutdown_configuration is optional,
+    # if omitted the live encoding will not shut down automatically.
+    auto_shutdown_configuration = LiveAutoShutdownConfiguration(
+        bytes_read_timeout_seconds=bytes_read_timeout_seconds,
+        stream_timeout_minutes=stream_timeout_minutes
+    )
+
+    start_live_encoding_request = StartLiveChannelEncodingRequest(
+        dash_manifests=[live_dash_manifest],
+        hls_manifests=[live_hls_manifest],
+        stream_key=stream_key,
+        auto_shutdown_configuration=auto_shutdown_configuration
+    )
+
+    _start_live_encoding_and_wait_until_running(encoding=encoding, request=start_live_encoding_request)
+
+    live_encoding = _wait_for_live_encoding_details(encoding=encoding)
+
+    print("Live encoding is up and ready for ingest. RTMP URL: rtmp://{0}/live StreamKey: {1}"
+          .format(live_encoding.encoder_ip, live_encoding.stream_key))
+
+    # This will enable you to shut down the live encoding from within your script.
+    # In production, it is naturally recommended to stop the encoding by using the Bitmovin dashboard
+    # or an independent API call
+    # https://bitmovin.com/docs/encoding/api-reference/sections/encodings#/Encoding/PostEncodingEncodingsLiveStopByEncodingId
+
+    input("Press Enter to shutdown the live encoding...")
+
+    print("Shutting down live encoding.")
+    bitmovin_api.encoding.encodings.live.stop(encoding_id=encoding.id)
+    _wait_until_encoding_is_in_state(encoding=encoding, expected_status=Status.FINISHED)
+
+
+def _wait_until_encoding_is_in_state(encoding, expected_status):
+    # type: (Encoding, Status) -> None
+    """
+    Periodically checks the status of the encoding.
+
+    <p>Note: You can also use our webhooks API instead of polling the status. For more information
+    checkout the API spec:
+    https://bitmovin.com/docs/encoding/api-reference/sections/notifications-webhooks
+
+    <p>API endpoint:
+    https://bitmovin.com/docs/encoding/api-reference/sections/encodings#/Encoding/GetEncodingEncodingsStatusByEncodingId
+
+    :param encoding: The encoding that should have the expected status
+    :param expected_status: The expected status the provided encoding should have. See {@link Status}
+    """
+    check_interval_in_seconds = 5
+    max_attempts = max_minutes_to_wait_for_encoding_status * (60 / check_interval_in_seconds)
+    attempt = 0
+
+    while attempt < max_attempts:
+        task = bitmovin_api.encoding.encodings.status(encoding_id=encoding.id)
+        if task.status is expected_status:
+            return
+        if task.status is Status.ERROR:
+            _log_task_errors(task=task)
+            raise Exception("Encoding failed")
+
+        print("Encoding status is {0}. Waiting for status {1} ({2} / {3})"
+              .format(task.status, expected_status, attempt, max_attempts))
+
+        sleep(check_interval_in_seconds)
+
+        attempt += 1
+
+    raise Exception("Encoding did not switch to state {0} within {1} minutes. Aborting."
+                    .format(expected_status, max_minutes_to_wait_for_encoding_status))
+
+
+def _wait_for_live_encoding_details(encoding):
+    # type: (Encoding) -> LiveEncoding
+    """
+    Tries to get the live details of the encoding. It could take a few minutes until this info is
+    available.
+
+    <p>API endpoint:
+    https://bitmovin.com/docs/encoding/api-reference/sections/encodings#/Encoding/GetEncodingEncodingsLiveByEncodingId
+
+    :param encoding: The encoding for which the live encoding details should be retrieved
+    """
+
+    timeout_interval_seconds = 5
+    retries = 0
+    max_retries = (60 / timeout_interval_seconds) * max_minutes_to_wait_for_live_encoding_details
+
+    while retries < max_retries:
+        try:
+            return bitmovin_api.encoding.encodings.live.get(encoding_id=encoding.id)
+        except BitmovinError:
+            print("Failed to fetch live encoding details. Retrying... {0} / {1}"
+                  .format(retries, max_retries))
+            retries += 1
+            sleep(timeout_interval_seconds)
+
+    raise Exception("Live encoding details could not be fetched after {0} minutes"
+                    .format(max_minutes_to_wait_for_live_encoding_details))
+
+
+def _start_live_encoding_and_wait_until_running(encoding, request):
+    # type: (Encoding, StartLiveChannelEncodingRequest) -> None
+    """
+    This method starts the live encoding with HD option
+
+    <p>API endpoint:
+    https://bitmovin.com/docs/encoding/api-reference/sections/encodings#/Encoding/PostEncodingEncodingsLiveStartByEncodingId
+
+    :param encoding: The encoding that should be started and checked until it is running
+    :param request: The request object that is sent with the start call
+    """
+    bitmovin_api.encoding.encodings.live.hd.start(encoding_id=encoding.id, start_live_channel_encoding_request=request)
+    _wait_until_encoding_is_in_state(encoding=encoding, expected_status=Status.RUNNING)
+
+
+def _create_encoding(name, description):
+    # type: (str, str) -> Encoding
+    """
+    Creates an Encoding object. This is the base object to configure your encoding.
+
+    API endpoint:
+    https://bitmovin.com/docs/encoding/api-reference/sections/encodings#/Encoding/PostEncodingEncodings
+
+    :param name: A name that will help you identify the encoding in our dashboard (required)
+    :param description: A description of the encoding (optional)
+    """
+
+    encoding = Encoding(
+        name=name,
+        description=description
+    )
+
+    return bitmovin_api.encoding.encodings.create(encoding=encoding)
+
+
+def _get_rtmp_input():
+    # type: () -> RtmpInput
+    """
+    Retrieves the first RTMP input. This is an automatically generated resource and read-only.
+
+    <p>API endpoint:
+    https://bitmovin.com/docs/encoding/api-reference/sections/inputs#/Encoding/GetEncodingInputsRtmp
+    """
+
+    rtmp_inputs = bitmovin_api.encoding.inputs.rtmp.list()
+    return rtmp_inputs.items[0]
+
+
+def _create_s3_output(bucket_name, access_key, secret_key):
+    # type: (str, str, str) -> S3Output
+    """
+    Creates a resource representing an AWS S3 cloud storage bucket to which generated content will be transferred.
+    For alternative output methods see
+    <a href="https://bitmovin.com/docs/encoding/articles/supported-input-output-storages">
+    list of supported input and output storages</a>
+
+    <p>The provided credentials need to allow <i>read</i>, <i>write</i> and <i>list</i> operations.
+    <i>delete</i> should also be granted to allow overwriting of existings files. See <a
+    href="https://bitmovin.com/docs/encoding/faqs/how-do-i-create-a-aws-s3-bucket-which-can-be-used-as-output-location">
+    creating an S3 bucket and setting permissions</a> for further information
+
+    <p>For reasons of simplicity, a new output resource is created on each execution of this
+    example. In production use, this method should be replaced by a
+    <a href="https://bitmovin.com/docs/encoding/api-reference/sections/outputs#/Encoding/GetEncodingOutputsS3">
+    get call</a> retrieving an existing resource.
+
+    <p>API endpoint:
+    https://bitmovin.com/docs/encoding/api-reference/sections/outputs#/Encoding/PostEncodingOutputsS3
+
+    :param bucket_name: The name of the S3 bucket
+    :param access_key: The access key of your S3 account
+    :param secret_key: The secret key of your S3 account
+    """
+
+    s3_output = S3Output(
+        bucket_name=bucket_name,
+        access_key=access_key,
+        secret_key=secret_key
+    )
+
+    return bitmovin_api.encoding.outputs.s3.create(s3_output=s3_output)
+
+
+def _create_h264_video_configuration(height, bitrate):
+    # type: (int, int) -> H264VideoConfiguration
+    """
+    Creates a configuration for the H.264 video codec to be applied to video streams.
+
+    <p>The output resolution is defined by setting the height to 1080 pixels. Width will be
+    determined automatically to maintain the aspect ratio of your input video.
+
+    <p>To keep things simple, we use a quality-optimized VoD preset configuration, which will apply
+    proven settings for the codec. See <a
+    href="https://bitmovin.com/docs/encoding/tutorials/how-to-optimize-your-h264-codec-configuration-for-different-use-cases">How
+    to optimize your H264 codec configuration for different use-cases</a> for alternative presets.
+
+    <p>API endpoint:
+    https://bitmovin.com/docs/encoding/api-reference/sections/configurations#/Encoding/PostEncodingConfigurationsVideoH264
+    :param height: The height of the output video
+    :param bitrate: The target bitrate of the output video
+    """
+
+    config = H264VideoConfiguration(
+        name="H.264 {0} {1} Mbit/s".format(height, bitrate / (1000 * 1000)),
+        preset_configuration=PresetConfiguration.LIVE_STANDARD,
+        height=height,
+        width=math.ceil(aspect_ratio * height),
+        bitrate=bitrate
+    )
+
+    return bitmovin_api.encoding.configurations.video.h264.create(h264_video_configuration=config)
+
+
+def _create_stream(encoding, encoding_input, input_path, codec_configuration):
+    # type: (Encoding, Input, str, CodecConfiguration) -> Stream
+    """
+    Adds a video or audio stream to an encoding
+
+    <p>API endpoint:
+    https://bitmovin.com/docs/encoding/api-reference/sections/encodings#/Encoding/PostEncodingEncodingsStreamsByEncodingId
+
+    :param encoding: The encoding to which the stream will be added
+    :param encoding_input: The input resource providing the input file
+    :param input_path: The path to the input file
+    :param codec_configuration: The codec configuration to be applied to the stream
+    """
+
+    stream_input = StreamInput(
+        input_id=encoding_input.id,
+        input_path=input_path,
+        selection_mode=StreamSelectionMode.AUTO
+    )
+
+    stream = Stream(
+        input_streams=[stream_input],
+        codec_config_id=codec_configuration.id
+    )
+
+    return bitmovin_api.encoding.encodings.streams.create(encoding_id=encoding.id, stream=stream)
+
+
+def _create_fmp4_muxing(encoding, output, output_path, stream):
+    # type: (Encoding, Output, str, Stream) -> Fmp4Muxing
+    """
+    Creates a fragmented MP4 muxing. This will generate segments with a given segment length for
+    adaptive streaming.
+
+    <p>API endpoint:
+    https://bitmovin.com/docs/encoding/api-reference/all#/Encoding/PostEncodingEncodingsMuxingsFmp4ByEncodingId
+
+    :param encoding: The encoding where to add the muxing to
+    :param output: The output that should be used for the muxing to write the segments to
+    :param output_path: The output path where the fragmented segments will be written to
+    :param stream: The stream that is associated with the muxing
+    """
+
+    muxing = Fmp4Muxing(
+        outputs=[_build_encoding_output(output=output, output_path=output_path)],
+        segment_length=4.0,
+        streams=[MuxingStream(stream_id=stream.id)]
+    )
+
+    return bitmovin_api.encoding.encodings.muxings.fmp4.create(encoding_id=encoding.id, fmp4_muxing=muxing)
+
+
+def _create_aac_audio_configuration(bitrate):
+    # type: (int) -> AacAudioConfiguration
+    """
+    Creates a configuration for the AAC audio codec to be applied to audio streams.
+
+    <p>API endpoint:
+    https://bitmovin.com/docs/encoding/api-reference/sections/configurations#/Encoding/PostEncodingConfigurationsAudioAac
+
+    :param bitrate: The target bitrate of the output audio
+    """
+
+    config = AacAudioConfiguration(
+        name="AAC {0} kbit/s".format(bitrate / 1000),
+        bitrate=bitrate
+    )
+
+    return bitmovin_api.encoding.configurations.audio.aac.create(aac_audio_configuration=config)
+
+
+def _generate_hls_manifest(encoding, output, output_path):
+    # type: (Encoding, Output, str) -> HlsManifestDefault
+    """
+    Creates an HLS default manifest that automatically includes all representations configured in
+    the encoding.
+
+    <p>API endpoint:
+    https://bitmovin.com/docs/encoding/api-reference/sections/manifests#/Encoding/PostEncodingManifestsHlsDefault
+
+    :param encoding: The encoding for which the manifest should be generated
+    :param output: The output to which the manifest should be written
+    :param output_path: The path to which the manifest should be written
+    """
+
+    hls_manifest_default = HlsManifestDefault(
+        encoding_id=encoding.id,
+        outputs=[_build_encoding_output(output, output_path)],
+        name="master.m3u8",
+        version=HlsManifestDefaultVersion.V1
+    )
+
+    return bitmovin_api.encoding.manifests.hls.default.create(hls_manifest_default=hls_manifest_default)
+
+
+def _generate_dash_manifest(encoding, output, output_path):
+    # type: (Encoding, Output, str) -> DashManifestDefault
+    """
+    Creates a DASH default manifest that automatically includes all representations configured in
+    the encoding.
+
+    <p>API endpoint:
+    https://bitmovin.com/docs/encoding/api-reference/sections/manifests#/Encoding/PostEncodingManifestsDash
+
+    :param encoding: The encoding for which the manifest should be generated
+    :param output: The output to which the manifest should be written
+    :param output_path: The path to which the manifest should be written
+    """
+
+    dash_manifest_default = DashManifestDefault(
+        encoding_id=encoding.id,
+        manifest_name="stream.mpd",
+        version=DashManifestDefaultVersion.V1,
+        outputs=[_build_encoding_output(output, output_path)]
+    )
+
+    return bitmovin_api.encoding.manifests.dash.default.create(dash_manifest_default=dash_manifest_default)
+
+
+def _build_encoding_output(output, output_path):
+    # type: (Output, str) -> EncodingOutput
+    """
+    Builds an EncodingOutput object which defines where the output content (e.g. of a muxing) will be written to.
+    Public read permissions will be set for the files written, so they can be accessed easily via HTTP.
+
+    :param output: The output resource to be used by the EncodingOutput
+    :param output_path: The path where the content will be written to
+    """
+
+    acl_entry = AclEntry(
+        permission=AclPermission.PUBLIC_READ
+    )
+
+    return EncodingOutput(
+        output_path=_build_absolute_path(relative_path=output_path),
+        output_id=output.id,
+        acl=[acl_entry]
+    )
+
+
+def _build_absolute_path(relative_path):
+    # type: (str) -> str
+    """
+    Builds an absolute path by concatenating the S3_OUTPUT_BASE_PATH configuration parameter, the
+    name of this example and the given relative path
+
+    <p>e.g.: /s3/base/path/exampleName/relative/path
+
+    :param relative_path: The relative path that is concatenated
+    """
+
+    return path.join(config_provider.get_s3_output_base_path(), EXAMPLE_NAME + "/", relative_path)
+
+
+def _log_task_errors(task):
+    # type: (Task) -> None
+
+    if task is None:
+        return
+
+    filtered = [x for x in task.messages if x.type is MessageType.ERROR]
+
+    for message in filtered:
+        print(message.text)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
Update bitmovin-api-sdk client version in examples to 1.174.0 
Update dependencies

REST endpoint: https://developer.bitmovin.com/encoding/reference/postencodingencodingslivechannelstartbyencodingid