### PR TITLE
Remove refs/heads from URL

### DIFF
--- a/bitmovin-encoding-template.json
+++ b/bitmovin-encoding-template.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://raw.githubusercontent.com/bitmovin/bitmovin-api-sdk-examples/refs/heads/main/bitmovin-encoding-template.json",
+  "$id": "https://raw.githubusercontent.com/bitmovin/bitmovin-api-sdk-examples/main/bitmovin-encoding-template.json",
   "title": "Bitmovin Encoding Template JSON Schema",
   "description": "An encoding workflow from a single configuration template",
   "properties": {


### PR DESCRIPTION
`refs/heads` can be omitted in URL: https://raw.githubusercontent.com/bitmovin/bitmovin-api-sdk-examples/main/bitmovin-encoding-template.json (refers to https://github.com/bitmovin/bitmovin-api-sdk-examples/pull/65)